### PR TITLE
Ingestion pipeline: IMAP adapter, LLM extraction, PDF renderer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,8 @@ repos:
           - pydantic>=2.0
           - click>=8.1
           - types-python-slugify
+          - python-dotenv>=1.0
+          - "psycopg[binary]>=3.1"
         args: [--config-file=pyproject.toml]
         pass_filenames: false
         entry: mypy src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 # Pydantic models need these imports at runtime for type resolution
 "src/receipt_index/models.py" = ["TC003"]
+# pydantic-ai Agent uses Pydantic output types that need runtime imports
+"src/receipt_index/extraction.py" = ["TC003"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["receipt_index"]
@@ -70,7 +72,7 @@ warn_unused_configs = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["slugify.*", "weasyprint.*"]
+module = ["slugify.*", "weasyprint.*", "pydantic_ai.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
@@ -85,11 +87,7 @@ source = ["receipt_index"]
 omit = [
     # Stub modules — not yet implemented
     "src/receipt_index/cli.py",
-    "src/receipt_index/config.py",
     "src/receipt_index/db.py",
-    "src/receipt_index/extraction.py",
-    "src/receipt_index/renderer.py",
-    "src/receipt_index/adapters/*",
 ]
 
 [tool.coverage.report]

--- a/src/receipt_index/adapters/imap.py
+++ b/src/receipt_index/adapters/imap.py
@@ -1,1 +1,206 @@
-"""IMAP source adapter (Phase 1b)."""
+"""IMAP source adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import imaplib
+import logging
+from email import message_from_bytes
+from email.header import decode_header
+from email.utils import parsedate_to_datetime
+from typing import TYPE_CHECKING, cast
+
+from receipt_index.models import Attachment, RawReceipt
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from email.message import Message
+
+    from receipt_index.config import ImapConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ImapAdapter:
+    """Fetch unprocessed receipts from an IMAP mailbox."""
+
+    def __init__(self, config: ImapConfig) -> None:
+        self.config = config
+
+    def fetch_unprocessed(self, processed_ids: set[str]) -> Iterator[RawReceipt]:
+        """Connect to IMAP, fetch messages, yield those not yet processed."""
+        conn: imaplib.IMAP4_SSL | None = None
+        try:
+            conn = self._connect()
+            msg_ids = self._fetch_message_ids(conn)
+
+            for msg_id in msg_ids:
+                raw_email = self._fetch_message(conn, msg_id)
+                if raw_email is None:
+                    continue
+
+                msg = message_from_bytes(raw_email)
+                source_id = self._get_message_id(msg)
+
+                if source_id in processed_ids:
+                    logger.debug("Skipping already-processed message %s", source_id)
+                    continue
+
+                try:
+                    receipt = self._parse_message(msg, source_id)
+                    yield receipt
+                except Exception:
+                    logger.warning(
+                        "Failed to parse message %s", source_id, exc_info=True
+                    )
+        finally:
+            if conn is not None:
+                try:
+                    conn.logout()
+                except Exception:
+                    logger.debug("Error during IMAP logout", exc_info=True)
+
+    def _connect(self) -> imaplib.IMAP4_SSL:
+        """Establish an IMAP4_SSL connection and authenticate."""
+        conn = imaplib.IMAP4_SSL(self.config.host, self.config.port)
+        conn.login(self.config.username, self.config.password)
+        return conn
+
+    def _fetch_message_ids(self, conn: imaplib.IMAP4_SSL) -> list[bytes]:
+        """Select folder and return all message sequence numbers."""
+        conn.select(self.config.folder, readonly=True)
+        _status, data = conn.search(None, "ALL")
+        raw = data[0]
+        if not raw:
+            return []
+        return cast("list[bytes]", raw.split())
+
+    def _fetch_message(self, conn: imaplib.IMAP4_SSL, msg_id: bytes) -> bytes | None:
+        """Fetch a single message by sequence number."""
+        _status, data = conn.fetch(msg_id.decode(), "(RFC822)")
+        if not data or data[0] is None:
+            return None
+        part = data[0]
+        if isinstance(part, tuple):
+            return part[1]
+        return None
+
+    def _parse_message(self, msg: Message, source_id: str) -> RawReceipt:
+        """Convert an email Message to a RawReceipt."""
+        subject = self._decode_header_value(msg.get("Subject", ""))
+        sender = self._decode_header_value(msg.get("From", ""))
+
+        date_str = msg.get("Date")
+        email_date = parsedate_to_datetime(date_str) if date_str else None
+
+        html_body, text_body, attachments = self._extract_body_and_attachments(msg)
+
+        from datetime import UTC, datetime
+
+        return RawReceipt(
+            source_id=source_id,
+            subject=subject,
+            sender=sender,
+            date=email_date or datetime.now(tz=UTC),
+            html_body=html_body,
+            text_body=text_body,
+            attachments=attachments,
+        )
+
+    @staticmethod
+    def _get_message_id(msg: Message) -> str:
+        """Extract a unique identifier for the message.
+
+        Uses the Message-ID header if present; falls back to a hash
+        of subject + date + sender.
+        """
+        message_id = msg.get("Message-ID")
+        if message_id:
+            return message_id.strip()
+
+        subject = msg.get("Subject", "")
+        date = msg.get("Date", "")
+        sender = msg.get("From", "")
+        key = f"{subject}|{date}|{sender}"
+        return hashlib.sha256(key.encode()).hexdigest()
+
+    @staticmethod
+    def _decode_header_value(value: str | None) -> str:
+        """Decode an RFC 2047 encoded header value."""
+        if not value:
+            return ""
+        parts = decode_header(value)
+        decoded_parts: list[str] = []
+        for data, charset in parts:
+            if isinstance(data, bytes):
+                decoded_parts.append(data.decode(charset or "utf-8", errors="replace"))
+            else:
+                decoded_parts.append(data)
+        return "".join(decoded_parts)
+
+    @staticmethod
+    def _extract_body_and_attachments(
+        msg: Message,
+    ) -> tuple[str | None, str | None, list[Attachment]]:
+        """Walk MIME tree and extract body content and attachments."""
+        html_body: str | None = None
+        text_body: str | None = None
+        attachments: list[Attachment] = []
+
+        if not msg.is_multipart():
+            content_type = msg.get_content_type()
+            charset = msg.get_content_charset() or "utf-8"
+            raw_payload = msg.get_payload(decode=True)
+            if raw_payload is None:
+                return None, None, []
+            payload = cast("bytes", raw_payload)
+            if content_type == "text/html":
+                html_body = payload.decode(charset, errors="replace")
+            elif content_type == "text/plain":
+                text_body = payload.decode(charset, errors="replace")
+            return html_body, text_body, attachments
+
+        for part in msg.walk():
+            content_type = part.get_content_type()
+            disposition = str(part.get("Content-Disposition", ""))
+
+            # Skip multipart containers
+            if part.get_content_maintype() == "multipart":
+                continue
+
+            raw_payload = part.get_payload(decode=True)
+            if raw_payload is None:
+                continue
+            payload = cast("bytes", raw_payload)
+
+            # Attachment if it has a filename or explicit disposition
+            filename = part.get_filename()
+            is_attachment = bool(filename) or "attachment" in disposition.lower()
+
+            if is_attachment:
+                attachments.append(
+                    Attachment(
+                        filename=filename or "unnamed",
+                        content_type=content_type,
+                        data=payload,
+                    )
+                )
+            elif content_type == "text/html" and html_body is None:
+                charset = part.get_content_charset() or "utf-8"
+                html_body = payload.decode(charset, errors="replace")
+            elif content_type == "text/plain" and text_body is None:
+                charset = part.get_content_charset() or "utf-8"
+                text_body = payload.decode(charset, errors="replace")
+            elif content_type.startswith("image/"):
+                # Inline images without filename
+                content_id = part.get("Content-ID", "")
+                name = content_id.strip("<>") if content_id else "inline-image"
+                attachments.append(
+                    Attachment(
+                        filename=name,
+                        content_type=content_type,
+                        data=payload,
+                    )
+                )
+
+        return html_body, text_body, attachments

--- a/src/receipt_index/config.py
+++ b/src/receipt_index/config.py
@@ -3,11 +3,23 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 from dotenv import load_dotenv
 
 load_dotenv()
+
+
+@dataclass(frozen=True)
+class ImapConfig:
+    """IMAP connection configuration."""
+
+    host: str
+    username: str
+    password: str
+    port: int = 993
+    folder: str = "INBOX"
 
 
 def get_database_url() -> str:
@@ -26,3 +38,56 @@ def get_store_path() -> Path:
     working directory changes during execution.
     """
     return Path(os.environ.get("RECEIPT_STORE_PATH", "./data/receipts")).resolve()
+
+
+def get_imap_config() -> ImapConfig:
+    """Build IMAP configuration from environment variables.
+
+    Required: IMAP_HOST, IMAP_USERNAME, IMAP_PASSWORD
+    Optional: IMAP_PORT (default 993), IMAP_FOLDER (default INBOX)
+    """
+    host = os.environ.get("IMAP_HOST")
+    username = os.environ.get("IMAP_USERNAME")
+    password = os.environ.get("IMAP_PASSWORD")
+
+    missing = []
+    if not host:
+        missing.append("IMAP_HOST")
+    if not username:
+        missing.append("IMAP_USERNAME")
+    if not password:
+        missing.append("IMAP_PASSWORD")
+
+    if missing:
+        msg = f"Required environment variables not set: {', '.join(missing)}"
+        raise ValueError(msg)
+
+    port_str = os.environ.get("IMAP_PORT", "993")
+    port = int(port_str)
+
+    folder = os.environ.get("IMAP_FOLDER", "INBOX")
+
+    return ImapConfig(
+        host=host,  # type: ignore[arg-type]
+        username=username,  # type: ignore[arg-type]
+        password=password,  # type: ignore[arg-type]
+        port=port,
+        folder=folder,
+    )
+
+
+def get_anthropic_api_key() -> str:
+    """Return the ANTHROPIC_API_KEY from the environment."""
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        msg = "ANTHROPIC_API_KEY environment variable is required"
+        raise ValueError(msg)
+    return key
+
+
+def get_llm_model() -> str:
+    """Return the LLM model identifier.
+
+    Defaults to claude-haiku-4-5-20251001.
+    """
+    return os.environ.get("LLM_MODEL", "claude-haiku-4-5-20251001")

--- a/src/receipt_index/extraction.py
+++ b/src/receipt_index/extraction.py
@@ -1,1 +1,108 @@
-"""LLM-based metadata extraction (Phase 1b)."""
+"""LLM-based metadata extraction using pydantic-ai."""
+
+from __future__ import annotations
+
+import logging
+from html.parser import HTMLParser
+from typing import Any
+
+from pydantic_ai import Agent
+
+from receipt_index.config import get_anthropic_api_key, get_llm_model
+from receipt_index.models import RawReceipt, ReceiptMetadata
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+You are a receipt metadata extractor. Given an email that contains or forwards \
+a receipt, extract the following fields:
+
+- vendor: The canonical business name (e.g. "Amazon", not "no-reply@amazon.com")
+- amount: The total amount charged (numeric, e.g. 42.99)
+- currency: ISO 4217 currency code (e.g. "USD", "CAD", "EUR")
+- date: The purchase/transaction date (YYYY-MM-DD), NOT the email send date
+- description: Brief summary of what was purchased (optional)
+- confidence: Your confidence in the extraction from 0.0 to 1.0. \
+Use below 0.5 if the email may not be a receipt or key fields are uncertain.
+
+Handle forwarded receipts by looking at the original receipt content. \
+For multi-item orders, use the total amount. If the currency is not stated, \
+assume USD.\
+"""
+
+
+def create_extraction_agent() -> Agent[None, ReceiptMetadata]:
+    """Create a pydantic-ai Agent configured for receipt extraction."""
+    # Ensure API key is available (fail fast)
+    get_anthropic_api_key()
+
+    model_name = get_llm_model()
+    return Agent(
+        f"anthropic:{model_name}",
+        output_type=ReceiptMetadata,
+        system_prompt=_SYSTEM_PROMPT,
+    )
+
+
+def extract_metadata(
+    raw: RawReceipt,
+    *,
+    agent: Agent[None, ReceiptMetadata] | None = None,
+) -> ReceiptMetadata:
+    """Extract structured metadata from a raw receipt email.
+
+    Accepts an optional agent for dependency injection in tests.
+    """
+    if agent is None:
+        agent = create_extraction_agent()
+
+    prompt = _build_prompt(raw)
+    result: Any = agent.run_sync(prompt)
+    return result.output  # type: ignore[no-any-return]
+
+
+def _build_prompt(raw: RawReceipt) -> str:
+    """Build the user prompt from raw receipt data."""
+    parts = [
+        f"Subject: {raw.subject}",
+        f"From: {raw.sender}",
+        f"Date: {raw.date.isoformat()}",
+        "",
+        "--- Email Body ---",
+    ]
+
+    if raw.text_body:
+        parts.append(raw.text_body)
+    elif raw.html_body:
+        parts.append(_strip_html_tags(raw.html_body))
+    else:
+        parts.append("(no body content)")
+
+    return "\n".join(parts)
+
+
+def _strip_html_tags(html: str) -> str:
+    """Remove HTML tags, returning only text content."""
+    stripper = _HTMLTagStripper()
+    stripper.feed(html)
+    return stripper.get_text()
+
+
+class _HTMLTagStripper(HTMLParser):
+    """HTMLParser subclass that strips tags and returns text."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        self._parts.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        self._parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self._parts.append(f"&#{name};")
+
+    def get_text(self) -> str:
+        return "".join(self._parts)

--- a/src/receipt_index/renderer.py
+++ b/src/receipt_index/renderer.py
@@ -1,1 +1,119 @@
-"""Email-to-PDF rendering (Phase 1b)."""
+"""Email-to-PDF rendering."""
+
+from __future__ import annotations
+
+import base64
+import html
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from receipt_index.models import Attachment, RawReceipt
+
+logger = logging.getLogger(__name__)
+
+PLAIN_TEXT_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  body {{ font-family: monospace; font-size: 12px; margin: 2em; }}
+  .header {{ border-bottom: 1px solid #ccc; padding-bottom: 1em; margin-bottom: 1em; }}
+  .header p {{ margin: 0.2em 0; }}
+  pre {{ white-space: pre-wrap; word-wrap: break-word; }}
+</style>
+</head>
+<body>
+<div class="header">
+  <p><strong>Subject:</strong> {subject}</p>
+  <p><strong>From:</strong> {sender}</p>
+  <p><strong>Date:</strong> {date}</p>
+</div>
+<pre>{body}</pre>
+</body>
+</html>
+"""
+
+
+def render_pdf(raw: RawReceipt) -> bytes:
+    """Render a RawReceipt to PDF bytes.
+
+    Strategy (in order of preference):
+    1. If a PDF attachment exists, return it directly
+    2. If HTML body exists, render it via weasyprint
+    3. If text body exists, wrap in HTML template and render
+    4. Render a minimal page with just the email headers
+    """
+    # 1. PDF attachment pass-through
+    pdf_data = _find_pdf_attachment(raw.attachments)
+    if pdf_data is not None:
+        return pdf_data
+
+    # 2. HTML body rendering
+    if raw.html_body:
+        return _render_html_to_pdf(raw.html_body, raw.attachments)
+
+    # 3. Text body rendering
+    if raw.text_body:
+        return _render_text_to_pdf(raw)
+
+    # 4. Minimal fallback — headers only
+    return _render_text_to_pdf(raw)
+
+
+def _find_pdf_attachment(attachments: list[Attachment]) -> bytes | None:
+    """Return the data of the first PDF attachment, or None."""
+    for att in attachments:
+        if att.content_type.lower() == "application/pdf":
+            return att.data
+    return None
+
+
+def _render_html_to_pdf(html_content: str, attachments: list[Attachment]) -> bytes:
+    """Render HTML to PDF, embedding any inline images."""
+    html_with_images = _embed_inline_images(html_content, attachments)
+    return _html_to_pdf_bytes(html_with_images)
+
+
+def _embed_inline_images(html_content: str, attachments: list[Attachment]) -> str:
+    """Replace cid: references with data: URIs from attachments."""
+    attachment_map: dict[str, Attachment] = {}
+    for att in attachments:
+        if att.content_type.startswith("image/"):
+            # Map by filename (which may be the Content-ID)
+            attachment_map[att.filename] = att
+
+    if not attachment_map:
+        return html_content
+
+    def replace_cid(match: re.Match[str]) -> str:
+        cid = match.group(1)
+        att = attachment_map.get(cid)
+        if att is None:
+            return match.group(0)
+        b64 = base64.b64encode(att.data).decode("ascii")
+        return f"data:{att.content_type};base64,{b64}"
+
+    return re.sub(r"cid:([^\s\"'>]+)", replace_cid, html_content)
+
+
+def _render_text_to_pdf(raw: RawReceipt) -> bytes:
+    """Wrap text body in HTML template and render to PDF."""
+    body = html.escape(raw.text_body or "(no body content)")
+    rendered = PLAIN_TEXT_TEMPLATE.format(
+        subject=html.escape(raw.subject),
+        sender=html.escape(raw.sender),
+        date=html.escape(raw.date.isoformat()),
+        body=body,
+    )
+    return _html_to_pdf_bytes(rendered)
+
+
+def _html_to_pdf_bytes(html_content: str) -> bytes:
+    """Convert HTML string to PDF bytes via weasyprint."""
+    import weasyprint
+
+    doc = weasyprint.HTML(string=html_content)
+    return doc.write_pdf()  # type: ignore[no-any-return]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
+
+from receipt_index.config import ImapConfig
+from receipt_index.models import RawReceipt
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -16,3 +20,27 @@ def store_root(tmp_path: Path) -> Path:
     root = tmp_path / "receipts"
     root.mkdir()
     return root
+
+
+@pytest.fixture
+def imap_config() -> ImapConfig:
+    """Provide a test IMAP configuration."""
+    return ImapConfig(
+        host="imap.example.com",
+        username="test@example.com",
+        password="secret",  # pragma: allowlist secret
+        port=993,
+        folder="INBOX",
+    )
+
+
+@pytest.fixture
+def sample_raw_receipt() -> RawReceipt:
+    """Provide a minimal RawReceipt for extraction and renderer tests."""
+    return RawReceipt(
+        source_id="<test-123@example.com>",
+        subject="Your Amazon.com order",
+        sender="no-reply@amazon.com",
+        date=datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
+        text_body="Order Total: $42.99\nItem: Python Cookbook",
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,109 @@
+"""Tests for receipt_index.config."""
+
+from __future__ import annotations
+
+import pytest
+
+from receipt_index.config import (
+    ImapConfig,
+    get_anthropic_api_key,
+    get_imap_config,
+    get_llm_model,
+)
+
+
+class TestGetImapConfig:
+    """Tests for get_imap_config()."""
+
+    def test_valid_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
+        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
+        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
+
+        config = get_imap_config()
+
+        assert config.host == "mail.example.com"
+        assert config.username == "user@example.com"
+        assert config.password == "pass123"  # pragma: allowlist secret
+        assert config.port == 993
+        assert config.folder == "INBOX"
+
+    def test_custom_port_and_folder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
+        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
+        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
+        monkeypatch.setenv("IMAP_PORT", "143")
+        monkeypatch.setenv("IMAP_FOLDER", "Receipts")
+
+        config = get_imap_config()
+
+        assert config.port == 143
+        assert config.folder == "Receipts"
+
+    def test_missing_host_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("IMAP_HOST", raising=False)
+        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
+        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
+
+        with pytest.raises(ValueError, match="IMAP_HOST"):
+            get_imap_config()
+
+    def test_missing_username_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
+        monkeypatch.delenv("IMAP_USERNAME", raising=False)
+        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
+
+        with pytest.raises(ValueError, match="IMAP_USERNAME"):
+            get_imap_config()
+
+    def test_missing_password_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
+        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
+        monkeypatch.delenv("IMAP_PASSWORD", raising=False)
+
+        with pytest.raises(ValueError, match="IMAP_PASSWORD"):
+            get_imap_config()
+
+    def test_missing_all_required_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("IMAP_HOST", raising=False)
+        monkeypatch.delenv("IMAP_USERNAME", raising=False)
+        monkeypatch.delenv("IMAP_PASSWORD", raising=False)
+
+        with pytest.raises(
+            ValueError, match=r"IMAP_HOST.*IMAP_USERNAME.*IMAP_PASSWORD"
+        ):
+            get_imap_config()
+
+    def test_config_is_frozen(self) -> None:
+        config = ImapConfig(
+            host="mail.example.com",
+            username="user@example.com",
+            password="pass",  # pragma: allowlist secret
+        )
+        with pytest.raises(AttributeError):
+            config.host = "other.example.com"  # type: ignore[misc]
+
+
+class TestGetAnthropicApiKey:
+    """Tests for get_anthropic_api_key()."""
+
+    def test_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+        assert get_anthropic_api_key() == "sk-ant-test-key"
+
+    def test_key_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+            get_anthropic_api_key()
+
+
+class TestGetLlmModel:
+    """Tests for get_llm_model()."""
+
+    def test_default_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        assert get_llm_model() == "claude-haiku-4-5-20251001"
+
+    def test_custom_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_MODEL", "claude-sonnet-4-20250514")
+        assert get_llm_model() == "claude-sonnet-4-20250514"

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -1,0 +1,148 @@
+"""Tests for receipt_index.extraction."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from receipt_index.extraction import _build_prompt, _strip_html_tags, extract_metadata
+from receipt_index.models import RawReceipt, ReceiptMetadata
+
+
+class TestBuildPrompt:
+    """Tests for _build_prompt."""
+
+    def test_includes_subject_sender_date(self, sample_raw_receipt: RawReceipt) -> None:
+        prompt = _build_prompt(sample_raw_receipt)
+        assert "Subject: Your Amazon.com order" in prompt
+        assert "From: no-reply@amazon.com" in prompt
+        assert "2025-06-15" in prompt
+
+    def test_uses_text_body(self, sample_raw_receipt: RawReceipt) -> None:
+        prompt = _build_prompt(sample_raw_receipt)
+        assert "Order Total: $42.99" in prompt
+        assert "Item: Python Cookbook" in prompt
+
+    def test_strips_html_when_no_text_body(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            subject="HTML Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            html_body="<p>Your total is <strong>$99.00</strong></p>",
+        )
+        prompt = _build_prompt(raw)
+        assert "Your total is $99.00" in prompt
+        assert "<p>" not in prompt
+        assert "<strong>" not in prompt
+
+    def test_prefers_text_over_html(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            subject="Both",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            text_body="Text version",
+            html_body="<p>HTML version</p>",
+        )
+        prompt = _build_prompt(raw)
+        assert "Text version" in prompt
+        assert "HTML version" not in prompt
+
+    def test_handles_no_body(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            subject="Empty",
+            sender="x@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        prompt = _build_prompt(raw)
+        assert "(no body content)" in prompt
+
+
+class TestStripHtmlTags:
+    """Tests for _strip_html_tags."""
+
+    def test_simple_tags(self) -> None:
+        assert _strip_html_tags("<p>Hello</p>") == "Hello"
+
+    def test_nested_tags(self) -> None:
+        result = _strip_html_tags("<div><p>Nested <em>text</em></p></div>")
+        assert result == "Nested text"
+
+    def test_empty_string(self) -> None:
+        assert _strip_html_tags("") == ""
+
+    def test_no_tags(self) -> None:
+        assert _strip_html_tags("Plain text") == "Plain text"
+
+    def test_preserves_entity_refs(self) -> None:
+        result = _strip_html_tags("<p>Price &amp; tax</p>")
+        assert "Price" in result
+        assert "tax" in result
+
+    def test_attributes_stripped(self) -> None:
+        result = _strip_html_tags('<a href="http://example.com">Link</a>')
+        assert result == "Link"
+        assert "href" not in result
+
+
+class TestExtractMetadata:
+    """Tests for extract_metadata."""
+
+    def test_returns_receipt_metadata(self, sample_raw_receipt: RawReceipt) -> None:
+        expected = ReceiptMetadata(
+            vendor="Amazon",
+            amount=Decimal("42.99"),
+            date=date(2025, 6, 15),
+            confidence=0.95,
+        )
+
+        mock_result = MagicMock()
+        mock_result.output = expected
+
+        mock_agent = MagicMock()
+        mock_agent.run_sync.return_value = mock_result
+
+        result = extract_metadata(sample_raw_receipt, agent=mock_agent)
+
+        assert result == expected
+        assert result.vendor == "Amazon"
+        assert result.amount == Decimal("42.99")
+
+    def test_passes_prompt_to_agent(self, sample_raw_receipt: RawReceipt) -> None:
+        mock_result = MagicMock()
+        mock_result.output = ReceiptMetadata(
+            vendor="Amazon",
+            amount=Decimal("42.99"),
+            date=date(2025, 6, 15),
+            confidence=0.95,
+        )
+
+        mock_agent = MagicMock()
+        mock_agent.run_sync.return_value = mock_result
+
+        extract_metadata(sample_raw_receipt, agent=mock_agent)
+
+        call_args = mock_agent.run_sync.call_args
+        prompt = call_args[0][0]
+        assert "Subject: Your Amazon.com order" in prompt
+        assert "Order Total: $42.99" in prompt
+
+    def test_uses_injected_agent(self, sample_raw_receipt: RawReceipt) -> None:
+        mock_result = MagicMock()
+        mock_result.output = ReceiptMetadata(
+            vendor="Test",
+            amount=Decimal("1.00"),
+            date=date(2025, 1, 1),
+            confidence=0.5,
+        )
+
+        mock_agent = MagicMock()
+        mock_agent.run_sync.return_value = mock_result
+
+        extract_metadata(sample_raw_receipt, agent=mock_agent)
+
+        # Agent's run_sync should have been called exactly once
+        mock_agent.run_sync.assert_called_once()

--- a/tests/unit/test_imap_adapter.py
+++ b/tests/unit/test_imap_adapter.py
@@ -1,0 +1,359 @@
+"""Tests for receipt_index.adapters.imap."""
+
+from __future__ import annotations
+
+import hashlib
+from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from receipt_index.adapters.imap import ImapAdapter
+
+if TYPE_CHECKING:
+    from receipt_index.config import ImapConfig
+
+
+def _make_simple_email(
+    *,
+    subject: str = "Test Subject",
+    sender: str = "sender@example.com",
+    date: str = "Mon, 15 Jun 2025 10:30:00 +0000",
+    message_id: str | None = "<test-1@example.com>",
+    body: str = "Hello, World!",
+    html: bool = False,
+) -> bytes:
+    """Build a simple email message as bytes."""
+    subtype = "html" if html else "plain"
+    msg = MIMEText(body, subtype)
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["Date"] = date
+    if message_id:
+        msg["Message-ID"] = message_id
+    return msg.as_bytes()
+
+
+def _make_multipart_email(
+    *,
+    subject: str = "Test Subject",
+    sender: str = "sender@example.com",
+    date: str = "Mon, 15 Jun 2025 10:30:00 +0000",
+    message_id: str = "<test-multi@example.com>",
+    text_body: str | None = "Plain text body",
+    html_body: str | None = None,
+    attachments: list[tuple[str, str, bytes]] | None = None,
+    inline_images: list[tuple[str, str, bytes]] | None = None,
+) -> bytes:
+    """Build a multipart email with optional attachments and inline images."""
+    msg = MIMEMultipart("mixed")
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["Date"] = date
+    msg["Message-ID"] = message_id
+
+    if text_body or html_body:
+        alt = MIMEMultipart("alternative")
+        if text_body:
+            alt.attach(MIMEText(text_body, "plain"))
+        if html_body:
+            alt.attach(MIMEText(html_body, "html"))
+        msg.attach(alt)
+
+    if attachments:
+        for filename, content_type, data in attachments:
+            _maintype, subtype = content_type.split("/", 1)
+            att = MIMEApplication(data, subtype)
+            att.add_header("Content-Disposition", "attachment", filename=filename)
+            att["Content-Type"] = content_type
+            msg.attach(att)
+
+    if inline_images:
+        for content_id, content_type, data in inline_images:
+            _maintype, subtype = content_type.split("/", 1)
+            img = MIMEImage(data, subtype)
+            img.add_header("Content-ID", f"<{content_id}>")
+            img.add_header("Content-Disposition", "inline")
+            msg.attach(img)
+
+    return msg.as_bytes()
+
+
+class TestGetMessageId:
+    """Tests for _get_message_id."""
+
+    def test_extracts_message_id_header(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_simple_email(message_id="<unique-123@mail.com>")
+        msg = message_from_bytes(raw)
+        result = ImapAdapter._get_message_id(msg)
+        assert result == "<unique-123@mail.com>"
+
+    def test_strips_whitespace_from_message_id(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_simple_email(message_id="  <spaced@mail.com>  ")
+        msg = message_from_bytes(raw)
+        result = ImapAdapter._get_message_id(msg)
+        assert result == "<spaced@mail.com>"
+
+    def test_fallback_hash_when_no_message_id(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_simple_email(message_id=None)
+        msg = message_from_bytes(raw)
+        result = ImapAdapter._get_message_id(msg)
+
+        # Should be a SHA-256 hex digest
+        assert len(result) == 64
+        expected_key = f"{msg['Subject']}|{msg['Date']}|{msg['From']}"
+        expected = hashlib.sha256(expected_key.encode()).hexdigest()
+        assert result == expected
+
+
+class TestDecodeHeaderValue:
+    """Tests for _decode_header_value."""
+
+    def test_simple_ascii(self) -> None:
+        assert ImapAdapter._decode_header_value("Hello World") == "Hello World"
+
+    def test_rfc2047_encoded(self) -> None:
+        encoded = "=?utf-8?B?SMOpbGzDqA==?="
+        result = ImapAdapter._decode_header_value(encoded)
+        assert "H" in result  # Contains the decoded character
+
+    def test_none_returns_empty(self) -> None:
+        assert ImapAdapter._decode_header_value(None) == ""
+
+    def test_empty_returns_empty(self) -> None:
+        assert ImapAdapter._decode_header_value("") == ""
+
+
+class TestExtractBodyAndAttachments:
+    """Tests for _extract_body_and_attachments."""
+
+    def test_plain_text_only(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_simple_email(body="Just text", html=False)
+        msg = message_from_bytes(raw)
+        html_body, text_body, attachments = ImapAdapter._extract_body_and_attachments(
+            msg
+        )
+        assert text_body == "Just text"
+        assert html_body is None
+        assert attachments == []
+
+    def test_html_only(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_simple_email(body="<h1>Hello</h1>", html=True)
+        msg = message_from_bytes(raw)
+        html_body, text_body, attachments = ImapAdapter._extract_body_and_attachments(
+            msg
+        )
+        assert html_body == "<h1>Hello</h1>"
+        assert text_body is None
+        assert attachments == []
+
+    def test_multipart_with_text_and_html(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_multipart_email(
+            text_body="Plain version",
+            html_body="<p>HTML version</p>",
+        )
+        msg = message_from_bytes(raw)
+        html_body, text_body, attachments = ImapAdapter._extract_body_and_attachments(
+            msg
+        )
+        assert text_body == "Plain version"
+        assert html_body == "<p>HTML version</p>"
+        assert attachments == []
+
+    def test_pdf_attachment(self) -> None:
+        from email import message_from_bytes
+
+        pdf_data = b"%PDF-1.4 fake"
+        raw = _make_multipart_email(
+            attachments=[("receipt.pdf", "application/pdf", pdf_data)]
+        )
+        msg = message_from_bytes(raw)
+        _html, _text, attachments = ImapAdapter._extract_body_and_attachments(msg)
+        assert len(attachments) == 1
+        assert attachments[0].filename == "receipt.pdf"
+        assert attachments[0].content_type == "application/pdf"
+        assert attachments[0].data == pdf_data
+
+    def test_inline_image(self) -> None:
+        from email import message_from_bytes
+
+        img_data = b"\x89PNG\r\n\x1a\n"  # PNG header bytes
+        raw = _make_multipart_email(
+            html_body='<img src="cid:logo123">',
+            inline_images=[("logo123", "image/png", img_data)],
+        )
+        msg = message_from_bytes(raw)
+        _html, _text, attachments = ImapAdapter._extract_body_and_attachments(msg)
+        # Inline image should be captured as an attachment
+        image_atts = [a for a in attachments if a.content_type.startswith("image/")]
+        assert len(image_atts) >= 1
+
+    def test_multiple_attachments(self) -> None:
+        from email import message_from_bytes
+
+        raw = _make_multipart_email(
+            attachments=[
+                ("file1.pdf", "application/pdf", b"pdf1"),
+                ("file2.csv", "text/csv", b"csv data"),
+            ]
+        )
+        msg = message_from_bytes(raw)
+        _html, _text, attachments = ImapAdapter._extract_body_and_attachments(msg)
+        assert len(attachments) == 2
+        filenames = {a.filename for a in attachments}
+        assert "file1.pdf" in filenames
+        assert "file2.csv" in filenames
+
+
+class TestFetchUnprocessed:
+    """Tests for the fetch_unprocessed flow."""
+
+    def _mock_imap_connection(self, messages: dict[bytes, bytes]) -> MagicMock:
+        """Create a mock IMAP4_SSL with predefined messages."""
+        conn = MagicMock()
+        conn.select.return_value = ("OK", [b"1"])
+
+        msg_ids = b" ".join(messages.keys()) if messages else b""
+        conn.search.return_value = ("OK", [msg_ids])
+
+        def fake_fetch(msg_id: str, _fmt: str) -> tuple[str, list[object]]:
+            # msg_id comes in as str (decoded in _fetch_message)
+            data = messages.get(msg_id.encode())
+            if data is None:
+                return ("OK", [None])
+            return ("OK", [(b"1 (RFC822 {100})", data)])
+
+        conn.fetch.side_effect = fake_fetch
+        return conn
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_yields_unprocessed_messages(
+        self, mock_ssl: MagicMock, imap_config: ImapConfig
+    ) -> None:
+        email1 = _make_simple_email(
+            message_id="<msg-1@example.com>", subject="Receipt 1"
+        )
+        email2 = _make_simple_email(
+            message_id="<msg-2@example.com>", subject="Receipt 2"
+        )
+
+        conn = self._mock_imap_connection({b"1": email1, b"2": email2})
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        results = list(adapter.fetch_unprocessed(set()))
+
+        assert len(results) == 2
+        assert results[0].source_id == "<msg-1@example.com>"
+        assert results[1].source_id == "<msg-2@example.com>"
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_skips_processed_messages(
+        self, mock_ssl: MagicMock, imap_config: ImapConfig
+    ) -> None:
+        email1 = _make_simple_email(
+            message_id="<msg-1@example.com>", subject="Receipt 1"
+        )
+        email2 = _make_simple_email(
+            message_id="<msg-2@example.com>", subject="Receipt 2"
+        )
+
+        conn = self._mock_imap_connection({b"1": email1, b"2": email2})
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        results = list(adapter.fetch_unprocessed({"<msg-1@example.com>"}))
+
+        assert len(results) == 1
+        assert results[0].source_id == "<msg-2@example.com>"
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_empty_folder(self, mock_ssl: MagicMock, imap_config: ImapConfig) -> None:
+        conn = self._mock_imap_connection({})
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        results = list(adapter.fetch_unprocessed(set()))
+
+        assert results == []
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_logout_called_on_success(
+        self, mock_ssl: MagicMock, imap_config: ImapConfig
+    ) -> None:
+        conn = self._mock_imap_connection({})
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        list(adapter.fetch_unprocessed(set()))
+
+        conn.logout.assert_called_once()
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_logout_called_on_error(
+        self, mock_ssl: MagicMock, imap_config: ImapConfig
+    ) -> None:
+        conn = MagicMock()
+        conn.select.side_effect = Exception("Connection lost")
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        with pytest.raises(Exception, match="Connection lost"):
+            list(adapter.fetch_unprocessed(set()))
+
+        conn.logout.assert_called_once()
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_connection_uses_config(
+        self, mock_ssl: MagicMock, imap_config: ImapConfig
+    ) -> None:
+        conn = self._mock_imap_connection({})
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        list(adapter.fetch_unprocessed(set()))
+
+        mock_ssl.assert_called_once_with("imap.example.com", 993)
+        conn.login.assert_called_once_with("test@example.com", "secret")
+        conn.select.assert_called_once_with("INBOX", readonly=True)
+
+    @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
+    def test_parses_email_fields(
+        self, mock_ssl: MagicMock, imap_config: ImapConfig
+    ) -> None:
+        email_bytes = _make_simple_email(
+            subject="Your Order",
+            sender="shop@store.com",
+            date="Mon, 15 Jun 2025 10:30:00 +0000",
+            message_id="<order-1@store.com>",
+            body="Total: $50.00",
+        )
+
+        conn = self._mock_imap_connection({b"1": email_bytes})
+        mock_ssl.return_value = conn
+
+        adapter = ImapAdapter(imap_config)
+        results = list(adapter.fetch_unprocessed(set()))
+
+        assert len(results) == 1
+        receipt = results[0]
+        assert receipt.subject == "Your Order"
+        assert receipt.sender == "shop@store.com"
+        assert receipt.text_body == "Total: $50.00"
+        assert receipt.source_id == "<order-1@store.com>"

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -1,0 +1,253 @@
+"""Tests for receipt_index.renderer."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from receipt_index.models import Attachment, RawReceipt
+from receipt_index.renderer import (
+    _embed_inline_images,
+    _find_pdf_attachment,
+    _html_to_pdf_bytes,
+    _render_text_to_pdf,
+    render_pdf,
+)
+
+
+class TestRenderPdf:
+    """Tests for the top-level render_pdf function."""
+
+    def test_pdf_attachment_passthrough(self) -> None:
+        pdf_data = b"%PDF-1.4 test content"
+        raw = RawReceipt(
+            source_id="test",
+            subject="Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            attachments=[
+                Attachment(
+                    filename="receipt.pdf",
+                    content_type="application/pdf",
+                    data=pdf_data,
+                )
+            ],
+        )
+        result = render_pdf(raw)
+        assert result == pdf_data
+
+    @patch("receipt_index.renderer._html_to_pdf_bytes")
+    def test_html_body_rendered(self, mock_pdf: pytest.fixture) -> None:
+        mock_pdf.return_value = b"pdf-from-html"
+        raw = RawReceipt(
+            source_id="test",
+            subject="HTML Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            html_body="<p>Your receipt</p>",
+        )
+        result = render_pdf(raw)
+        assert result == b"pdf-from-html"
+        mock_pdf.assert_called_once()
+
+    @patch("receipt_index.renderer._html_to_pdf_bytes")
+    def test_text_body_rendered(self, mock_pdf: pytest.fixture) -> None:
+        mock_pdf.return_value = b"pdf-from-text"
+        raw = RawReceipt(
+            source_id="test",
+            subject="Text Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            text_body="Your total: $42.99",
+        )
+        result = render_pdf(raw)
+        assert result == b"pdf-from-text"
+
+    @patch("receipt_index.renderer._html_to_pdf_bytes")
+    def test_no_body_fallback(self, mock_pdf: pytest.fixture) -> None:
+        mock_pdf.return_value = b"pdf-fallback"
+        raw = RawReceipt(
+            source_id="test",
+            subject="Empty",
+            sender="x@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        result = render_pdf(raw)
+        assert result == b"pdf-fallback"
+
+    def test_pdf_attachment_preferred_over_html(self) -> None:
+        pdf_data = b"%PDF-1.4 original"
+        raw = RawReceipt(
+            source_id="test",
+            subject="Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            html_body="<p>Receipt HTML</p>",
+            attachments=[
+                Attachment(
+                    filename="receipt.pdf",
+                    content_type="application/pdf",
+                    data=pdf_data,
+                )
+            ],
+        )
+        result = render_pdf(raw)
+        assert result == pdf_data
+
+
+class TestFindPdfAttachment:
+    """Tests for _find_pdf_attachment."""
+
+    def test_finds_pdf(self) -> None:
+        pdf_data = b"%PDF data"
+        attachments = [
+            Attachment(
+                filename="doc.pdf", content_type="application/pdf", data=pdf_data
+            )
+        ]
+        assert _find_pdf_attachment(attachments) == pdf_data
+
+    def test_returns_none_when_no_pdf(self) -> None:
+        attachments = [
+            Attachment(filename="image.png", content_type="image/png", data=b"png")
+        ]
+        assert _find_pdf_attachment(attachments) is None
+
+    def test_returns_none_for_empty_list(self) -> None:
+        assert _find_pdf_attachment([]) is None
+
+    def test_first_pdf_wins(self) -> None:
+        attachments = [
+            Attachment(
+                filename="first.pdf",
+                content_type="application/pdf",
+                data=b"first",
+            ),
+            Attachment(
+                filename="second.pdf",
+                content_type="application/pdf",
+                data=b"second",
+            ),
+        ]
+        assert _find_pdf_attachment(attachments) == b"first"
+
+    def test_ignores_non_pdf(self) -> None:
+        attachments = [
+            Attachment(filename="img.jpg", content_type="image/jpeg", data=b"jpg"),
+            Attachment(filename="doc.pdf", content_type="application/pdf", data=b"pdf"),
+        ]
+        assert _find_pdf_attachment(attachments) == b"pdf"
+
+
+class TestEmbedInlineImages:
+    """Tests for _embed_inline_images."""
+
+    def test_replaces_cid_reference(self) -> None:
+        img_data = b"\x89PNG"
+        attachments = [
+            Attachment(filename="logo", content_type="image/png", data=img_data)
+        ]
+        html = '<img src="cid:logo">'
+        result = _embed_inline_images(html, attachments)
+
+        expected_b64 = base64.b64encode(img_data).decode("ascii")
+        assert f"data:image/png;base64,{expected_b64}" in result
+        assert "cid:" not in result
+
+    def test_multiple_images(self) -> None:
+        attachments = [
+            Attachment(filename="img1", content_type="image/png", data=b"png1"),
+            Attachment(filename="img2", content_type="image/jpeg", data=b"jpg2"),
+        ]
+        html_content = '<img src="cid:img1"><img src="cid:img2">'
+        result = _embed_inline_images(html_content, attachments)
+
+        assert "data:image/png;base64," in result
+        assert "data:image/jpeg;base64," in result
+
+    def test_no_cid_passthrough(self) -> None:
+        html_content = '<img src="https://example.com/img.png">'
+        result = _embed_inline_images(html_content, [])
+        assert result == html_content
+
+    def test_missing_attachment_keeps_cid(self) -> None:
+        html_content = '<img src="cid:missing">'
+        attachments = [
+            Attachment(filename="other", content_type="image/png", data=b"png")
+        ]
+        result = _embed_inline_images(html_content, attachments)
+        assert "cid:missing" in result
+
+    def test_non_image_attachments_ignored(self) -> None:
+        html_content = '<img src="cid:doc">'
+        attachments = [
+            Attachment(filename="doc", content_type="application/pdf", data=b"pdf")
+        ]
+        result = _embed_inline_images(html_content, attachments)
+        # PDF attachments should not be in the image map
+        assert "cid:doc" in result
+
+
+class TestRenderTextToPdf:
+    """Tests for _render_text_to_pdf."""
+
+    @patch("receipt_index.renderer._html_to_pdf_bytes")
+    def test_template_includes_subject_and_sender(
+        self, mock_pdf: pytest.fixture
+    ) -> None:
+        mock_pdf.return_value = b"pdf-bytes"
+        raw = RawReceipt(
+            source_id="test",
+            subject="My Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 3, 15, tzinfo=UTC),
+            text_body="Total: $100",
+        )
+        _render_text_to_pdf(raw)
+
+        call_args = mock_pdf.call_args[0][0]
+        assert "My Receipt" in call_args
+        assert "shop@example.com" in call_args
+        assert "2025-03-15" in call_args
+        assert "Total: $100" in call_args
+
+    @patch("receipt_index.renderer._html_to_pdf_bytes")
+    def test_html_escapes_body(self, mock_pdf: pytest.fixture) -> None:
+        mock_pdf.return_value = b"pdf-bytes"
+        raw = RawReceipt(
+            source_id="test",
+            subject="Test",
+            sender="x@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            text_body="Price: <script>alert('xss')</script>",
+        )
+        _render_text_to_pdf(raw)
+
+        call_args = mock_pdf.call_args[0][0]
+        assert "<script>" not in call_args
+        assert "&lt;script&gt;" in call_args
+
+
+class TestHtmlToPdfBytes:
+    """Integration tests with real weasyprint."""
+
+    @pytest.fixture(autouse=True)
+    def _suppress_weasyprint_warnings(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Suppress noisy weasyprint CSS warnings in test output."""
+        caplog.set_level(logging.ERROR, logger="weasyprint")
+
+    def test_produces_valid_pdf(self) -> None:
+        result = _html_to_pdf_bytes("<html><body><p>Hello</p></body></html>")
+        assert isinstance(result, bytes)
+        assert result[:5] == b"%PDF-"
+
+    def test_unicode_content(self) -> None:
+        result = _html_to_pdf_bytes(
+            "<html><body><p>Price: \u20ac42.99</p></body></html>"
+        )
+        assert isinstance(result, bytes)
+        assert result[:5] == b"%PDF-"


### PR DESCRIPTION
## Summary

Implements the three Phase 1b pipeline components for issue #3:

- **IMAP adapter** — Fetch emails via IMAP4_SSL, parse MIME trees, extract bodies/attachments, Message-ID based deduplication with hash fallback
- **LLM extraction** — pydantic-ai Agent with structured `ReceiptMetadata` output, HTML tag stripping, prompt assembly from raw receipt data
- **PDF renderer** — PDF attachment pass-through, HTML-to-PDF via weasyprint, text-to-PDF with template, CID inline image embedding
- **Config** — `ImapConfig` frozen dataclass, `get_imap_config()`, `get_anthropic_api_key()`, `get_llm_model()`
- **Pre-commit** — Added `python-dotenv` and `psycopg` to mypy hook dependencies

94 tests, 92% coverage. All pre-commit hooks pass.

Closes #3

## Test plan

- [x] `make format-check` — ruff lint and format pass
- [x] `make typecheck` — mypy strict mode passes
- [x] `make test` — 94 tests pass, 92.47% coverage (threshold: 80%)
- [x] Pre-commit hooks all pass (ruff, mypy, detect-secrets, etc.)
- [x] Smoke test: `uv run python -c "from receipt_index.extraction import create_extraction_agent"` imports successfully