### PR TITLE
feat: structured ingest log for audit trail and failure review

### DIFF
--- a/db/migrations/receipt/000003_create_ingest_log_table.down.sql
+++ b/db/migrations/receipt/000003_create_ingest_log_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS receipt.ingest_log;

--- a/db/migrations/receipt/000003_create_ingest_log_table.up.sql
+++ b/db/migrations/receipt/000003_create_ingest_log_table.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS receipt.ingest_log (
+    id              UUID NOT NULL DEFAULT uuidv7(),
+    source_id       TEXT NOT NULL,
+    source_type     TEXT NOT NULL DEFAULT 'imap',
+    status          TEXT NOT NULL,
+    receipt_id      UUID,
+    vendor          TEXT,
+    amount          NUMERIC(12,2),
+    email_subject   TEXT,
+    email_sender    TEXT,
+    email_date      TIMESTAMPTZ,
+    error_message   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT pk_ingest_log PRIMARY KEY (id),
+    CONSTRAINT ck_ingest_log_status CHECK (status IN ('success', 'failed', 'skipped')),
+    CONSTRAINT fk_ingest_log_receipt FOREIGN KEY (receipt_id)
+        REFERENCES receipt.receipts (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_log_status
+    ON receipt.ingest_log (status);
+CREATE INDEX IF NOT EXISTS idx_ingest_log_source_id
+    ON receipt.ingest_log (source_id);
+CREATE INDEX IF NOT EXISTS idx_ingest_log_created_at
+    ON receipt.ingest_log (created_at);

--- a/db/migrations/receipt/000004_grant_ingest_log_access.down.sql
+++ b/db/migrations/receipt/000004_grant_ingest_log_access.down.sql
@@ -1,0 +1,2 @@
+REVOKE SELECT, INSERT ON receipt.ingest_log FROM receipt_index_dev_write;
+REVOKE SELECT ON receipt.ingest_log FROM receipt_index_dev_read;

--- a/db/migrations/receipt/000004_grant_ingest_log_access.up.sql
+++ b/db/migrations/receipt/000004_grant_ingest_log_access.up.sql
@@ -1,0 +1,10 @@
+-- Grant ingest_log table privileges to application roles.
+
+-- _all: full DDL access (runs migrations)
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA receipt TO receipt_index_dev_all;
+
+-- _write: insert + select on ingest_log
+GRANT SELECT, INSERT ON receipt.ingest_log TO receipt_index_dev_write;
+
+-- _read: SELECT only
+GRANT SELECT ON receipt.ingest_log TO receipt_index_dev_read;

--- a/db/migrations/receipt/000004_grant_ingest_log_access.up.sql
+++ b/db/migrations/receipt/000004_grant_ingest_log_access.up.sql
@@ -4,7 +4,10 @@
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA receipt TO receipt_index_dev_all;
 
 -- _write: insert + select on ingest_log
-GRANT SELECT, INSERT ON receipt.ingest_log TO receipt_index_dev_write;
+GRANT SELECT ON receipt.ingest_log TO receipt_index_dev_write;
+GRANT INSERT (source_id, source_type, status, receipt_id, vendor, amount,
+              email_subject, email_sender, email_date, error_message)
+    ON receipt.ingest_log TO receipt_index_dev_write;
 
 -- _read: SELECT only
 GRANT SELECT ON receipt.ingest_log TO receipt_index_dev_read;

--- a/src/receipt_index/cli.py
+++ b/src/receipt_index/cli.py
@@ -148,6 +148,42 @@ def search(
 
 
 @cli.command()
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format.",
+)
+def failures(output_format: str) -> None:
+    """List failed ingest attempts."""
+    from receipt_index.db import get_connection
+    from receipt_index.repository import get_ingest_failures
+
+    with get_connection() as conn:
+        results = get_ingest_failures(conn)
+
+    if output_format == "json":
+        data = [r.model_dump(mode="json") for r in results]
+        click.echo(json.dumps(data, indent=2, default=str))
+    else:
+        if not results:
+            click.echo("No failed ingests.")
+            return
+        click.echo(f"{'Date':<22} {'Sender':<30} {'Subject':<40} {'Error':<30}")
+        click.echo("-" * 124)
+        for r in results:
+            email_date = (
+                r.email_date.strftime("%Y-%m-%d %H:%M") if r.email_date else "—"
+            )
+            sender = (r.email_sender or "—")[:29]
+            subject = (r.email_subject or "—")[:39]
+            error = (r.error_message or "—")[:29]
+            click.echo(f"{email_date:<22} {sender:<30} {subject:<40} {error:<30}")
+        click.echo(f"\n{len(results)} failed ingest(s).")
+
+
+@cli.command()
 @click.argument("receipt_id")
 @click.option(
     "--output",

--- a/src/receipt_index/models.py
+++ b/src/receipt_index/models.py
@@ -61,3 +61,20 @@ class Receipt(BaseModel):
     email_date: datetime | None
     created_at: datetime
     updated_at: datetime
+
+
+class IngestLogEntry(BaseModel):
+    """A record of an ingest attempt (success, failure, or skip)."""
+
+    id: UUID
+    source_id: str
+    source_type: str
+    status: str
+    receipt_id: UUID | None
+    vendor: str | None
+    amount: Decimal | None
+    email_subject: str | None
+    email_sender: str | None
+    email_date: datetime | None
+    error_message: str | None
+    created_at: datetime

--- a/src/receipt_index/models.py
+++ b/src/receipt_index/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -69,7 +70,7 @@ class IngestLogEntry(BaseModel):
     id: UUID
     source_id: str
     source_type: str
-    status: str
+    status: Literal["success", "failed", "skipped"]
     receipt_id: UUID | None
     vendor: str | None
     amount: Decimal | None

--- a/src/receipt_index/pipeline.py
+++ b/src/receipt_index/pipeline.py
@@ -105,16 +105,23 @@ def run_ingest(
                 metadata.confidence,
             )
         except Exception as exc:
-            insert_ingest_log(
-                conn,
-                source_id=raw.source_id,
-                source_type="imap",
-                status="failed",
-                email_subject=raw.subject,
-                email_sender=raw.sender,
-                email_date=raw.date,
-                error_message=str(exc),
-            )
+            try:
+                insert_ingest_log(
+                    conn,
+                    source_id=raw.source_id,
+                    source_type="imap",
+                    status="failed",
+                    email_subject=raw.subject,
+                    email_sender=raw.sender,
+                    email_date=raw.date,
+                    error_message=str(exc),
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to write ingest log for %s",
+                    raw.source_id,
+                    exc_info=True,
+                )
             logger.warning(
                 "Failed to process message %s (subject=%s, sender=%s)",
                 raw.source_id,

--- a/src/receipt_index/pipeline.py
+++ b/src/receipt_index/pipeline.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 
 from receipt_index.extraction import extract_metadata
 from receipt_index.renderer import render_pdf
-from receipt_index.repository import get_processed_source_ids, insert_receipt
+from receipt_index.repository import (
+    get_processed_source_ids,
+    insert_ingest_log,
+    insert_receipt,
+)
 
 if TYPE_CHECKING:
     import psycopg
@@ -82,14 +86,42 @@ def run_ingest(
             )
             result.processed += 1
             result.receipts.append(receipt)
+            insert_ingest_log(
+                conn,
+                source_id=raw.source_id,
+                source_type="imap",
+                status="success",
+                receipt_id=receipt.id,
+                vendor=metadata.vendor,
+                amount=metadata.amount,
+                email_subject=raw.subject,
+                email_sender=raw.sender,
+                email_date=raw.date,
+            )
             logger.info(
                 "Processed receipt: %s (%s) confidence=%.2f",
                 metadata.vendor,
                 receipt.id,
                 metadata.confidence,
             )
-        except Exception:
-            logger.warning("Failed to process message %s", raw.source_id, exc_info=True)
+        except Exception as exc:
+            insert_ingest_log(
+                conn,
+                source_id=raw.source_id,
+                source_type="imap",
+                status="failed",
+                email_subject=raw.subject,
+                email_sender=raw.sender,
+                email_date=raw.date,
+                error_message=str(exc),
+            )
+            logger.warning(
+                "Failed to process message %s (subject=%s, sender=%s)",
+                raw.source_id,
+                raw.subject,
+                raw.sender,
+                exc_info=True,
+            )
             result.failed += 1
 
     return result

--- a/src/receipt_index/repository.py
+++ b/src/receipt_index/repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from receipt_index.models import Receipt
+from receipt_index.models import IngestLogEntry, Receipt
 
 if TYPE_CHECKING:
     from datetime import date, datetime
@@ -116,6 +116,62 @@ def search_receipts(
 
     cur = conn.execute(sql, params)
     return [Receipt.model_validate(row) for row in cur.fetchall()]
+
+
+def insert_ingest_log(
+    conn: psycopg.Connection[dict[str, Any]],
+    *,
+    source_id: str,
+    source_type: str,
+    status: str,
+    receipt_id: UUID | None = None,
+    vendor: str | None = None,
+    amount: Decimal | None = None,
+    email_subject: str | None = None,
+    email_sender: str | None = None,
+    email_date: datetime | None = None,
+    error_message: str | None = None,
+) -> IngestLogEntry:
+    """Insert an ingest log entry and return the validated model."""
+    cur = conn.execute(
+        """\
+        INSERT INTO receipt.ingest_log (
+            source_id, source_type, status, receipt_id, vendor, amount,
+            email_subject, email_sender, email_date, error_message
+        ) VALUES (
+            %(source_id)s, %(source_type)s, %(status)s, %(receipt_id)s,
+            %(vendor)s, %(amount)s, %(email_subject)s, %(email_sender)s,
+            %(email_date)s, %(error_message)s
+        )
+        RETURNING *
+        """,
+        {
+            "source_id": source_id,
+            "source_type": source_type,
+            "status": status,
+            "receipt_id": receipt_id,
+            "vendor": vendor,
+            "amount": amount,
+            "email_subject": email_subject,
+            "email_sender": email_sender,
+            "email_date": email_date,
+            "error_message": error_message,
+        },
+    )
+    row = cur.fetchone()
+    conn.commit()
+    return IngestLogEntry.model_validate(row)
+
+
+def get_ingest_failures(
+    conn: psycopg.Connection[dict[str, Any]],
+) -> list[IngestLogEntry]:
+    """Return all failed ingest log entries, newest first."""
+    cur = conn.execute(
+        "SELECT * FROM receipt.ingest_log WHERE status = 'failed' "
+        "ORDER BY created_at DESC"
+    )
+    return [IngestLogEntry.model_validate(row) for row in cur.fetchall()]
 
 
 def get_receipt_by_id(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,7 @@ _DB_DSN = (
 def _run_migrations(conn: psycopg.Connection[dict[str, Any]]) -> None:
     """Apply migrations inline so tests don't need golang-migrate.
 
-    Mirrors: public/000001, receipt/000001, receipt/000002.
+    Mirrors: public/000001, receipt/000001-000004.
     Keep in sync with db/migrations/ when schema changes.
     """
     # public/000001 — set_updated_at trigger function
@@ -94,6 +94,40 @@ def _run_migrations(conn: psycopg.Connection[dict[str, Any]]) -> None:
             EXECUTE FUNCTION public.set_updated_at()
         """
     )
+
+    # receipt/000003 — ingest_log table and indexes
+    conn.execute("DROP TABLE IF EXISTS receipt.ingest_log CASCADE")
+    conn.execute(
+        """\
+        CREATE TABLE receipt.ingest_log (
+            id              UUID NOT NULL DEFAULT uuidv7(),
+            source_id       TEXT NOT NULL,
+            source_type     TEXT NOT NULL DEFAULT 'imap',
+            status          TEXT NOT NULL,
+            receipt_id      UUID,
+            vendor          TEXT,
+            amount          NUMERIC(12,2),
+            email_subject   TEXT,
+            email_sender    TEXT,
+            email_date      TIMESTAMPTZ,
+            error_message   TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+            CONSTRAINT pk_ingest_log PRIMARY KEY (id),
+            CONSTRAINT ck_ingest_log_status
+                CHECK (status IN ('success', 'failed', 'skipped')),
+            CONSTRAINT fk_ingest_log_receipt FOREIGN KEY (receipt_id)
+                REFERENCES receipt.receipts (id) ON DELETE SET NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_ingest_log_status ON receipt.ingest_log (status)")
+    conn.execute(
+        "CREATE INDEX idx_ingest_log_source_id ON receipt.ingest_log (source_id)"
+    )
+    conn.execute(
+        "CREATE INDEX idx_ingest_log_created_at ON receipt.ingest_log (created_at)"
+    )
     conn.commit()
 
 
@@ -112,9 +146,9 @@ def pg_conn() -> Iterator[psycopg.Connection[dict[str, Any]]]:
 
 @pytest.fixture(autouse=True)
 def _truncate_receipts(pg_conn: psycopg.Connection[dict[str, Any]]) -> None:
-    """Clear the receipts table before each test."""
+    """Clear the receipts and ingest_log tables before each test."""
     pg_conn.rollback()  # clear any dangling transaction from a prior test failure
-    pg_conn.execute("TRUNCATE receipt.receipts")
+    pg_conn.execute("TRUNCATE receipt.ingest_log, receipt.receipts CASCADE")
     pg_conn.commit()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from click.testing import CliRunner
 
 from receipt_index.cli import cli
-from receipt_index.models import Receipt
+from receipt_index.models import IngestLogEntry, Receipt
 from receipt_index.pipeline import IngestResult
 
 _RECEIPT_ROW: dict[str, Any] = {
@@ -34,6 +34,23 @@ _RECEIPT_ROW: dict[str, Any] = {
 }
 
 _SAMPLE_RECEIPT = Receipt.model_validate(_RECEIPT_ROW)
+
+_FAILURE_ROW: dict[str, Any] = {
+    "id": UUID("019572a0-0000-7000-8000-000000000099"),
+    "source_id": "<fail-1@example.com>",
+    "source_type": "imap",
+    "status": "failed",
+    "receipt_id": None,
+    "vendor": None,
+    "amount": None,
+    "email_subject": "Your shipping update",
+    "email_sender": "noreply@example.com",
+    "email_date": datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
+    "error_message": "amount > 0 validation failed",
+    "created_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
+}
+
+_SAMPLE_FAILURE = IngestLogEntry.model_validate(_FAILURE_ROW)
 
 
 class TestIngestCommand:
@@ -229,6 +246,58 @@ class TestSearchCommand:
         )
         assert result.exit_code != 0
         assert "--amount cannot be combined" in result.output
+
+
+class TestFailuresCommand:
+    """Tests for the failures CLI command."""
+
+    @patch(
+        "receipt_index.repository.get_ingest_failures",
+        return_value=[_SAMPLE_FAILURE],
+    )
+    @patch("receipt_index.db.get_connection")
+    def test_failures_text_output(
+        self,
+        mock_conn: MagicMock,
+        mock_get: MagicMock,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["failures"])
+        assert result.exit_code == 0
+        assert "noreply@example.com" in result.output
+        assert "Your shipping update" in result.output
+        assert "1 failed ingest(s)" in result.output
+
+    @patch(
+        "receipt_index.repository.get_ingest_failures",
+        return_value=[_SAMPLE_FAILURE],
+    )
+    @patch("receipt_index.db.get_connection")
+    def test_failures_json_output(
+        self,
+        mock_conn: MagicMock,
+        mock_get: MagicMock,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["failures", "--output", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["status"] == "failed"
+        assert data[0]["error_message"] == "amount > 0 validation failed"
+
+    @patch("receipt_index.repository.get_ingest_failures", return_value=[])
+    @patch("receipt_index.db.get_connection")
+    def test_failures_empty(
+        self,
+        mock_conn: MagicMock,
+        mock_get: MagicMock,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["failures"])
+        assert result.exit_code == 0
+        assert "No failed ingests" in result.output
 
 
 class TestShowCommand:

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -75,6 +75,7 @@ def _mock_store() -> MagicMock:
 class TestRunIngest:
     """Tests for run_ingest."""
 
+    @patch("receipt_index.pipeline.insert_ingest_log")
     @patch("receipt_index.pipeline.insert_receipt", return_value=_SAMPLE_RECEIPT)
     @patch("receipt_index.pipeline.render_pdf", return_value=b"%PDF-fake")
     @patch("receipt_index.pipeline.extract_metadata", return_value=_SAMPLE_METADATA)
@@ -85,6 +86,7 @@ class TestRunIngest:
         mock_extract: MagicMock,
         mock_render: MagicMock,
         mock_insert: MagicMock,
+        mock_log: MagicMock,
     ) -> None:
         conn = _mock_conn()
         adapter = _mock_adapter([_make_raw()])
@@ -100,6 +102,9 @@ class TestRunIngest:
         mock_render.assert_called_once()
         store.save.assert_called_once()
         mock_insert.assert_called_once()
+        mock_log.assert_called_once()
+        _, kwargs = mock_log.call_args
+        assert kwargs["status"] == "success"
 
     @patch("receipt_index.pipeline.get_processed_source_ids", return_value=set())
     def test_dry_run_skips_processing(self, mock_get_ids: MagicMock) -> None:
@@ -113,6 +118,7 @@ class TestRunIngest:
         assert result.skipped == 2
         assert result.failed == 0
 
+    @patch("receipt_index.pipeline.insert_ingest_log")
     @patch("receipt_index.pipeline.insert_receipt", return_value=_SAMPLE_RECEIPT)
     @patch("receipt_index.pipeline.render_pdf", return_value=b"%PDF-fake")
     @patch("receipt_index.pipeline.extract_metadata", return_value=_SAMPLE_METADATA)
@@ -123,6 +129,7 @@ class TestRunIngest:
         mock_extract: MagicMock,
         mock_render: MagicMock,
         mock_insert: MagicMock,
+        mock_log: MagicMock,
     ) -> None:
         conn = _mock_conn()
         raws = [_make_raw(f"<msg-{i}@example.com>") for i in range(5)]
@@ -133,6 +140,7 @@ class TestRunIngest:
 
         assert result.processed == 2
 
+    @patch("receipt_index.pipeline.insert_ingest_log")
     @patch(
         "receipt_index.pipeline.extract_metadata",
         side_effect=RuntimeError("LLM error"),
@@ -142,6 +150,7 @@ class TestRunIngest:
         self,
         mock_get_ids: MagicMock,
         mock_extract: MagicMock,
+        mock_log: MagicMock,
     ) -> None:
         conn = _mock_conn()
         adapter = _mock_adapter([_make_raw(), _make_raw("<msg-2@example.com>")])
@@ -151,7 +160,12 @@ class TestRunIngest:
 
         assert result.failed == 2
         assert result.processed == 0
+        assert mock_log.call_count == 2
+        for call in mock_log.call_args_list:
+            assert call.kwargs["status"] == "failed"
+            assert "LLM error" in call.kwargs["error_message"]
 
+    @patch("receipt_index.pipeline.insert_ingest_log")
     @patch("receipt_index.pipeline.insert_receipt", return_value=_SAMPLE_RECEIPT)
     @patch("receipt_index.pipeline.render_pdf", return_value=b"%PDF-fake")
     @patch("receipt_index.pipeline.extract_metadata", return_value=_SAMPLE_METADATA)
@@ -162,6 +176,7 @@ class TestRunIngest:
         mock_extract: MagicMock,
         mock_render: MagicMock,
         mock_insert: MagicMock,
+        mock_log: MagicMock,
     ) -> None:
         conn = _mock_conn()
         adapter = _mock_adapter([_make_raw()])

--- a/uv.lock
+++ b/uv.lock
@@ -3287,11 +3287,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224 },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #17

## Summary

- Add `receipt.ingest_log` table to record every ingest attempt (success or failure) with email metadata, error messages, and receipt references
- Pipeline now logs both successes and failures to the table, and includes subject/sender in failure log messages
- New `receipt-index failures` CLI command lists failed ingests with date, sender, subject, and error (text and JSON output)
- Database migrations for table creation and role grants

## Changes

- **Migrations**: `000003_create_ingest_log_table` (table + indexes), `000004_grant_ingest_log_access` (role grants)
- **Model**: `IngestLogEntry` Pydantic model
- **Repository**: `insert_ingest_log()`, `get_ingest_failures()` 
- **Pipeline**: Logs success/failure entries after each message attempt; failure log message now includes subject and sender
- **CLI**: `receipt-index failures [--output text|json]`
- **Tests**: Unit tests for pipeline logging behavior and failures CLI command

## Test plan

- [x] Unit tests pass (168 passed, 93% coverage)
- [ ] Run migrations on dev database
- [ ] Run `receipt-index ingest --limit 5` and verify ingest_log entries created
- [ ] Run `receipt-index failures` to verify output
- [ ] Verify failures include email_subject, email_sender, error_message