### PR TITLE
feat: Phase 2 — Google Drive integration, config-based sources, and DLQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ env/
 *.swo
 *~
 
-# Environment
+# Environment and config
 .env
+receipt-index.yaml
 
 # Data
 data/
@@ -43,6 +44,12 @@ coverage.xml
 
 # Playwright browsers
 .playwright/
+
+# Local tools (golang-migrate, etc.)
+.bin/
+
+# Local working notes
+PHASE2-PLAN.md
 
 # OS
 .DS_Store

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,7 +156,7 @@
         "filename": "example.env",
         "hashed_secret": "0cf1f88c8e401efcd87269c5477fc60778601d61",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 9
       }
     ],
     "tests/integration/test_phase2.py": [
@@ -165,7 +165,7 @@
         "filename": "tests/integration/test_phase2.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 1283
+        "line_number": 1270
       }
     ],
     "tests/unit/test_auth.py": [
@@ -187,5 +187,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-22T18:36:06Z"
+  "generated_at": "2026-03-22T19:19:20Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -127,6 +123,15 @@
     }
   ],
   "results": {
+    "db/init/01-create-roles.sql": [
+      {
+        "type": "Secret Keyword",
+        "filename": "db/init/01-create-roles.sql",
+        "hashed_secret": "0cf1f88c8e401efcd87269c5477fc60778601d61",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
     "docker-compose.yml": [
       {
         "type": "Secret Keyword",
@@ -151,9 +156,36 @@
         "filename": "example.env",
         "hashed_secret": "0cf1f88c8e401efcd87269c5477fc60778601d61",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 10
+      }
+    ],
+    "tests/integration/test_phase2.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/integration/test_phase2.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 1283
+      }
+    ],
+    "tests/unit/test_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_auth.py",
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "tests/unit/test_config_loading.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config_loading.py",
+        "hashed_secret": "e6020a9a10139de8324c6db4309ec6a24404beac",
+        "is_verified": false,
+        "line_number": 134
       }
     ]
   },
-  "generated_at": "2026-03-08T19:29:58Z"
+  "generated_at": "2026-03-22T18:36:06Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,37 @@
 .PHONY: help setup lint format format-check typecheck test test-unit test-integration \
-       migrate-up migrate-down docker-db-up docker-db-down clean
+       check migrate-up migrate-down docker-up docker-down clean
+
+# Load .env if present (exports vars for migrate, docker compose, etc.)
+ifneq (,$(wildcard .env))
+  ENV_VARS := $(shell sed -e '/^\#/d' -e '/^$$/d' -e 's/\#.*//' -e 's/ *$$//' .env)
+  $(foreach var,$(ENV_VARS),$(eval export $(var)))
+endif
+
+# golang-migrate — auto-downloaded to .bin/ if not present
+MIGRATE_VERSION := 4.18.3
+MIGRATE_BIN := .bin/migrate
+MIGRATE_ARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+MIGRATE_OS := $(shell uname -s | tr A-Z a-z)
 
 help:  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-setup:  ## Install dependencies, Playwright browser, and pre-commit hooks
+$(MIGRATE_BIN):
+	@mkdir -p .bin
+	@echo "Downloading golang-migrate v$(MIGRATE_VERSION)..."
+	@curl -sL https://github.com/golang-migrate/migrate/releases/download/v$(MIGRATE_VERSION)/migrate.$(MIGRATE_OS)-$(MIGRATE_ARCH).tar.gz \
+		| tar xz -C .bin
+	@chmod +x $(MIGRATE_BIN)
+	@echo "golang-migrate installed at $(MIGRATE_BIN)"
+
+setup:  ## Install dependencies, Playwright browser, pre-commit hooks, and golang-migrate
+	@test -f .env || (cp example.env .env && echo "Created .env from example.env — edit with your credentials")
+	@test -f receipt-index.yaml || (cp example.receipt-index.yaml receipt-index.yaml && echo "Created receipt-index.yaml from example — edit with your settings")
 	uv sync --all-extras
 	PLAYWRIGHT_BROWSERS_PATH=.playwright uv run playwright install chromium
 	uv run pre-commit install
+	$(MAKE) $(MIGRATE_BIN)
 
 lint:  ## Run linting (ruff check)
 	uv run ruff check src/ tests/
@@ -30,21 +53,26 @@ test:  ## Run all tests with coverage
 test-unit:  ## Run unit tests only
 	uv run pytest tests/unit/ --cov-fail-under=80
 
-test-integration:  ## Run integration tests only
+test-integration:  ## Run integration tests only (requires docker-up)
 	uv run pytest tests/integration/ -m integration --cov-fail-under=60
 
-migrate-up:  ## Run all migrations in schema dependency order (uses MIGRATION_DATABASE_URL)
-	migrate -path db/migrations/public -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_public" up
-	migrate -path db/migrations/receipt -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_receipt" up
+check:  ## Run all checks (lint, format, typecheck, unit tests)
+	$(MAKE) format-check
+	$(MAKE) typecheck
+	$(MAKE) test-unit
 
-migrate-down:  ## Roll back the last migration for each schema (reverse order)
-	migrate -path db/migrations/receipt -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_receipt" down 1
-	migrate -path db/migrations/public -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_public" down 1
+migrate-up: $(MIGRATE_BIN)  ## Run all migrations in schema dependency order (uses MIGRATION_DATABASE_URL)
+	$(MIGRATE_BIN) -path db/migrations/public -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_public" up
+	$(MIGRATE_BIN) -path db/migrations/receipt -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_receipt" up
 
-docker-db-up:  ## Start PostgreSQL via Docker Compose
+migrate-down: $(MIGRATE_BIN)  ## Roll back the last migration for each schema (reverse order)
+	$(MIGRATE_BIN) -path db/migrations/receipt -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_receipt" down 1
+	$(MIGRATE_BIN) -path db/migrations/public -database "$${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_public" down 1
+
+docker-up:  ## Start Docker services (PostgreSQL, GreenMail)
 	docker compose up -d
 
-docker-db-down:  ## Stop PostgreSQL via Docker Compose
+docker-down:  ## Stop Docker services
 	docker compose down
 
 clean:  ## Remove build artifacts

--- a/db/migrations/receipt/000005_add_source_name_and_file_columns.down.sql
+++ b/db/migrations/receipt/000005_add_source_name_and_file_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE receipt.receipts
+    DROP COLUMN IF EXISTS source_name,
+    DROP COLUMN IF EXISTS file_name;

--- a/db/migrations/receipt/000005_add_source_name_and_file_columns.up.sql
+++ b/db/migrations/receipt/000005_add_source_name_and_file_columns.up.sql
@@ -1,0 +1,19 @@
+ALTER TABLE receipt.receipts
+    ADD COLUMN source_name TEXT,
+    ADD COLUMN file_name TEXT;
+
+-- Backfill existing rows with a placeholder name
+UPDATE receipt.receipts SET source_name = 'legacy-imap' WHERE source_name IS NULL;
+
+-- Enforce NOT NULL after backfill
+ALTER TABLE receipt.receipts ALTER COLUMN source_name SET NOT NULL;
+
+-- Grant write access to new columns
+GRANT INSERT (source_name, file_name)
+    ON receipt.receipts TO receipt_index_dev_write;
+GRANT UPDATE (source_name, file_name)
+    ON receipt.receipts TO receipt_index_dev_write;
+
+-- Grant read access to new columns
+GRANT SELECT (source_name, file_name)
+    ON receipt.receipts TO receipt_index_dev_read;

--- a/db/migrations/receipt/000006_allow_zero_amount.down.sql
+++ b/db/migrations/receipt/000006_allow_zero_amount.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE receipt.receipts
+    DROP CONSTRAINT ck_receipts_amount_non_negative,
+    ADD CONSTRAINT ck_receipts_amount_positive CHECK (amount > 0);

--- a/db/migrations/receipt/000006_allow_zero_amount.up.sql
+++ b/db/migrations/receipt/000006_allow_zero_amount.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE receipt.receipts
+    DROP CONSTRAINT ck_receipts_amount_positive,
+    ADD CONSTRAINT ck_receipts_amount_non_negative CHECK (amount >= 0);

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -7,9 +7,10 @@ Set up Receipt Search Index from scratch and run your first ingest.
 - **Python 3.11+** — [python.org](https://www.python.org/downloads/)
 - **uv** — [docs.astral.sh/uv](https://docs.astral.sh/uv/) (Python package manager)
 - **Docker** and Docker Compose — [docker.com](https://www.docker.com/)
-- **golang-migrate** — [github.com/golang-migrate/migrate](https://github.com/golang-migrate/migrate)
 - **Anthropic API key** — [console.anthropic.com](https://console.anthropic.com/)
 - An IMAP email account with receipts in a designated folder
+
+> **Note:** golang-migrate is downloaded automatically by `make setup` — no manual install needed.
 
 ## 1. Clone and Install
 

--- a/docs/user/production-setup.md
+++ b/docs/user/production-setup.md
@@ -52,21 +52,42 @@ GRANT CONNECT ON DATABASE receipt_index TO receipt_index_dev_read;
 
 The `_dev_` suffix in the role names is just a convention from the Docker dev setup — the grant migration references these names, so we reuse them here to keep things simple.
 
+### Alternative: Single Application Role
+
+If you prefer a simpler setup with one application role, create it and then add the grant target roles as members:
+
+```bash
+sudo -u postgres psql
+```
+
+```sql
+CREATE DATABASE receipt_index;
+
+-- Single application role
+CREATE ROLE receipt_index WITH LOGIN PASSWORD 'your-secure-password';  -- pragma: allowlist secret
+GRANT CONNECT ON DATABASE receipt_index TO receipt_index;
+
+-- Create grant target roles (referenced by migrations) and assign to the app role
+CREATE ROLE receipt_index_dev_write;
+CREATE ROLE receipt_index_dev_read;
+GRANT receipt_index_dev_write TO receipt_index;
+GRANT receipt_index_dev_read TO receipt_index;
+
+\q
+```
+
+This gives `receipt_index` all the permissions that the migrations grant to the `_write` and `_read` roles.
+
 ## 3. Run Migrations
 
 Set the migration URL to use the `postgres` superuser (or another superuser role) and point it at your native cluster:
 
 ```bash
 export MIGRATION_DATABASE_URL="postgresql://postgres@localhost:5432/receipt_index?sslmode=disable"
-
-migrate -path db/migrations/public \
-  -database "${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_public" up
-
-migrate -path db/migrations/receipt \
-  -database "${MIGRATION_DATABASE_URL}&x-migrations-table=schema_migrations_receipt" up
+make migrate-up
 ```
 
-The migrations create the `receipt` schema, tables, indexes, and grant permissions to the application roles created in step 2.
+This auto-downloads golang-migrate if needed, then applies all migrations in schema dependency order. The migrations create the `receipt` schema, tables, indexes, and grant permissions to the application roles created in step 2.
 
 ## 4. Configure `.env`
 

--- a/example.env
+++ b/example.env
@@ -3,7 +3,6 @@ IMAP_PASSWORD=app-specific-password
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Google Drive (optional, after running: receipt-index auth gdrive --client-credentials ...)
-# GDRIVE_CREDENTIALS_JSON='{"installed":{"client_id":"...","client_secret":"..."}}'
 # GDRIVE_TOKEN_JSON='{"token":"...","refresh_token":"...","client_id":"...","client_secret":"..."}'
 
 # Database — used by receipt-index.yaml and make migrate-up

--- a/example.env
+++ b/example.env
@@ -1,31 +1,19 @@
-# IMAP
-IMAP_HOST=imap.example.com
-IMAP_PORT=993
-IMAP_USERNAME=receipts@example.com
+# Secrets — referenced by receipt-index.yaml via ${VAR_NAME} interpolation
 IMAP_PASSWORD=app-specific-password
-IMAP_FOLDER=INBOX
-IMAP_USE_SSL=true
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Google Drive (optional, after running: receipt-index auth gdrive --client-credentials ...)
+# GDRIVE_CREDENTIALS_JSON='{"installed":{"client_id":"...","client_secret":"..."}}'
+# GDRIVE_TOKEN_JSON='{"token":"...","refresh_token":"...","client_id":"...","client_secret":"..."}'
+
+# Database — used by receipt-index.yaml and make migrate-up
+DATABASE_URL=postgresql://receipt_index_dev_write:localpass@localhost:15432/receipt_index_dev
+MIGRATION_DATABASE_URL=postgresql://main:localpass@localhost:15432/receipt_index_dev
 
 # Docker Compose — host ports (avoids conflicts with other services)
 POSTGRES_HOST_PORT=15432
 GREENMAIL_SMTP_PORT=3025
 GREENMAIL_IMAP_PORT=3143
 
-# Database — application connection (_write role)
-DATABASE_URL=postgresql://receipt_index_dev_write:localpass@localhost:15432/receipt_index_dev
-
-# Database — migrations (main superuser)
-MIGRATION_DATABASE_URL=postgresql://main:localpass@localhost:15432/receipt_index_dev
-
-# Anthropic
-ANTHROPIC_API_KEY=sk-ant-...
-
-# File Store
-RECEIPT_STORE_PATH=./data/receipts
-
 # Playwright — local browser install path (set by `make setup`)
 PLAYWRIGHT_BROWSERS_PATH=.playwright
-
-# Optional
-LOG_LEVEL=INFO
-LLM_MODEL=claude-haiku-4-5-20251001

--- a/example.receipt-index.yaml
+++ b/example.receipt-index.yaml
@@ -1,0 +1,56 @@
+# receipt-index.yaml — Application configuration
+#
+# Config file search order (first found wins):
+#   1. --config CLI flag
+#   2. RECEIPT_INDEX_CONFIG environment variable
+#   3. ./receipt-index.yaml (current working directory)
+#   4. ~/.config/receipt-index/config.yaml (XDG convention)
+#
+# Secrets use ${VAR_NAME} syntax for env var interpolation.
+# All referenced env vars must be set at runtime.
+
+# ---------------------------------------------------------------------------
+# Sources — one or more named receipt sources to ingest from
+# ---------------------------------------------------------------------------
+sources:
+  # IMAP email source
+  - name: personal-email
+    type: imap
+    host: mail.example.com
+    port: 993                          # default: 993
+    username: user@example.com
+    password: ${IMAP_PASSWORD}         # env var interpolation for secrets
+    folder: INBOX.Receipts             # default: INBOX
+    use_ssl: true                      # default: true
+
+  # Google Drive source (Phase 2)
+  # - name: scanned-receipts
+  #   type: gdrive
+  #   folder_id: "1aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+  #   credentials_json: ${GDRIVE_CREDENTIALS_JSON}  # OAuth client config JSON
+  #   token_json: ${GDRIVE_TOKEN_JSON}              # OAuth refresh token JSON
+
+# ---------------------------------------------------------------------------
+# Database — PostgreSQL connection
+# ---------------------------------------------------------------------------
+database:
+  url: ${DATABASE_URL}                 # e.g. postgresql://user:pass@localhost:5432/receipt_index  # pragma: allowlist secret
+
+# ---------------------------------------------------------------------------
+# File store — where rendered PDF receipts are saved
+# ---------------------------------------------------------------------------
+store:
+  path: ./data/receipts                # default: ./data/receipts
+
+# ---------------------------------------------------------------------------
+# LLM — metadata extraction provider
+# ---------------------------------------------------------------------------
+llm:
+  model: claude-haiku-4-5-20251001     # default: claude-haiku-4-5-20251001
+  api_key: ${ANTHROPIC_API_KEY}
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging:
+  level: INFO                          # DEBUG | INFO | WARNING | ERROR | CRITICAL

--- a/example.receipt-index.yaml
+++ b/example.receipt-index.yaml
@@ -27,8 +27,7 @@ sources:
   # - name: scanned-receipts
   #   type: gdrive
   #   folder_id: "1aBcDeFgHiJkLmNoPqRsTuVwXyZ"
-  #   credentials_json: ${GDRIVE_CREDENTIALS_JSON}  # OAuth client config JSON
-  #   token_json: ${GDRIVE_TOKEN_JSON}              # OAuth refresh token JSON
+  #   token_json: ${GDRIVE_TOKEN_JSON}              # from: receipt-index auth gdrive
 
 # ---------------------------------------------------------------------------
 # Database — PostgreSQL connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,17 @@ license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "click>=8.1",
+    "google-api-python-client>=2.0",
+    "google-auth>=2.0",
+    "google-auth-oauthlib>=1.0",
+    "Pillow>=10.0",
     "pydantic>=2.0",
     "pydantic-ai>=0.1",
     "psycopg[binary]>=3.1",
     "pdfplumber>=0.10",
     "playwright>=1.40",
     "python-dotenv>=1.0",
+    "pyyaml>=6.0",
     "python-slugify>=8.0",
     "weasyprint>=62.0",
 ]
@@ -60,6 +65,7 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 # Pydantic models need these imports at runtime for type resolution
 "src/receipt_index/models.py" = ["TC003"]
+"src/receipt_index/config.py" = ["TC003"]
 # pydantic-ai Agent uses Pydantic output types that need runtime imports
 "src/receipt_index/extraction.py" = ["TC003"]
 # pydantic-ai BinaryContent needs runtime import for Agent usage
@@ -76,7 +82,7 @@ warn_unused_configs = true
 mypy_path = "src"
 
 [[tool.mypy.overrides]]
-module = ["pdfplumber.*", "playwright.*", "slugify.*", "weasyprint.*", "pydantic_ai.*"]
+module = ["google.auth.*", "google.oauth2.*", "google_auth_oauthlib.*", "googleapiclient.*", "pdfplumber.*", "PIL.*", "playwright.*", "slugify.*", "weasyprint.*", "pydantic_ai.*", "yaml.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/receipt_index/adapters/gdrive.py
+++ b/src/receipt_index/adapters/gdrive.py
@@ -32,7 +32,7 @@ def _parse_drive_date(date_str: str) -> datetime:
 
     Google Drive returns timestamps like '2024-01-15T10:30:00.000Z'.
     """
-    # Handle fractional seconds by stripping them before parsing
+    # Replace Z suffix with +00:00 for fromisoformat compatibility
     cleaned = date_str.replace("Z", "+00:00")
     return datetime.fromisoformat(cleaned).astimezone(UTC)
 

--- a/src/receipt_index/adapters/gdrive.py
+++ b/src/receipt_index/adapters/gdrive.py
@@ -1,0 +1,155 @@
+"""Google Drive source adapter."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from receipt_index.models import RawReceipt
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from receipt_index.config import GdriveSourceConfig
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_MIME_TYPES = {
+    "application/pdf",
+    "image/jpeg",
+    "image/png",
+}
+
+_GOOGLE_DOCS_MIME_TYPE = "application/vnd.google-apps.document"
+
+_FILE_FIELDS = "nextPageToken, files(id, name, mimeType, modifiedTime)"
+
+
+def _parse_drive_date(date_str: str) -> datetime:
+    """Parse an RFC 3339 timestamp from the Google Drive API.
+
+    Google Drive returns timestamps like '2024-01-15T10:30:00.000Z'.
+    """
+    # Handle fractional seconds by stripping them before parsing
+    cleaned = date_str.replace("Z", "+00:00")
+    return datetime.fromisoformat(cleaned).astimezone(UTC)
+
+
+class GdriveAdapter:
+    """Fetch unprocessed receipt files from a Google Drive folder."""
+
+    def __init__(self, config: GdriveSourceConfig) -> None:
+        self.config = config
+
+    def fetch_unprocessed(self, processed_ids: set[str]) -> Iterator[RawReceipt]:
+        """List files in the configured Drive folder and yield unprocessed ones."""
+        service = self._build_service()
+        files = self._list_files(service)
+
+        for file_meta in files:
+            file_id: str = file_meta["id"]
+            if file_id in processed_ids:
+                logger.debug("Skipping already-processed file %s", file_id)
+                continue
+
+            result = self._download_file(service, file_meta)
+            if result is None:
+                continue
+
+            content, mime_type = result
+            yield RawReceipt(
+                source_id=file_id,
+                source_name=self.config.name,
+                source_type="gdrive",
+                date=_parse_drive_date(file_meta["modifiedTime"]),
+                file_name=file_meta["name"],
+                file_content=content,
+                file_content_type=mime_type,
+            )
+
+    def _build_service(self) -> Any:
+        """Create a Google Drive API service from stored credentials.
+
+        Uses lazy imports for Google API libraries.
+        """
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+
+        token_data = json.loads(self.config.token_json)
+        creds = Credentials.from_authorized_user_info(token_data)
+
+        if creds.expired and creds.refresh_token:
+            logger.debug("Refreshing expired Google Drive credentials")
+            creds.refresh(Request())
+
+        return build("drive", "v3", credentials=creds)
+
+    def _list_files(self, service: Any) -> list[dict[str, Any]]:
+        """List all files in the configured Google Drive folder.
+
+        Handles pagination via nextPageToken.
+        """
+        all_files: list[dict[str, Any]] = []
+        page_token: str | None = None
+        query = f"'{self.config.folder_id}' in parents and trashed = false"
+
+        while True:
+            request_kwargs: dict[str, Any] = {
+                "q": query,
+                "fields": _FILE_FIELDS,
+                "pageSize": 100,
+            }
+            if page_token is not None:
+                request_kwargs["pageToken"] = page_token
+
+            response: dict[str, Any] = service.files().list(**request_kwargs).execute()
+            files = response.get("files", [])
+            all_files.extend(files)
+
+            page_token = response.get("nextPageToken")
+            if page_token is None:
+                break
+
+        logger.info(
+            "Listed %d files in Drive folder %s",
+            len(all_files),
+            self.config.folder_id,
+        )
+        return all_files
+
+    def _download_file(
+        self, service: Any, file_meta: dict[str, Any]
+    ) -> tuple[bytes, str] | None:
+        """Download file content from Google Drive.
+
+        Returns (content_bytes, mime_type) or None if the file type
+        is unsupported.
+        """
+        file_id: str = file_meta["id"]
+        file_name: str = file_meta["name"]
+        mime_type: str = file_meta["mimeType"]
+
+        if mime_type in _SUPPORTED_MIME_TYPES:
+            logger.debug("Downloading file %s (%s)", file_name, mime_type)
+            content: bytes = service.files().get_media(fileId=file_id).execute()
+            return content, mime_type
+
+        if mime_type == _GOOGLE_DOCS_MIME_TYPE:
+            logger.debug("Exporting Google Doc %s as PDF", file_name)
+            content = (
+                service.files()
+                .export_media(fileId=file_id, mimeType="application/pdf")
+                .execute()
+            )
+            return content, "application/pdf"
+
+        logger.warning(
+            "Skipping unsupported file type %s for file %s (%s)",
+            mime_type,
+            file_name,
+            file_id,
+        )
+        return None

--- a/src/receipt_index/adapters/imap.py
+++ b/src/receipt_index/adapters/imap.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from email.message import Message
 
-    from receipt_index.config import ImapConfig
+    from receipt_index.config import ImapSourceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +28,9 @@ _MAX_CONNECT_RETRIES = 3
 class ImapAdapter:
     """Fetch unprocessed receipts from an IMAP mailbox."""
 
-    def __init__(self, config: ImapConfig) -> None:
+    def __init__(self, config: ImapSourceConfig) -> None:
         self.config = config
+        self.name = config.name
 
     def fetch_unprocessed(self, processed_ids: set[str]) -> Iterator[RawReceipt]:
         """Connect to IMAP, fetch messages, yield those not yet processed."""
@@ -128,9 +129,11 @@ class ImapAdapter:
 
         return RawReceipt(
             source_id=source_id,
+            source_name=self.name,
+            source_type="imap",
+            date=email_date or datetime.now(tz=UTC),
             subject=subject,
             sender=sender,
-            date=email_date or datetime.now(tz=UTC),
             html_body=html_body,
             text_body=text_body,
             attachments=attachments,

--- a/src/receipt_index/auth.py
+++ b/src/receipt_index/auth.py
@@ -1,0 +1,69 @@
+"""OAuth2 authentication flows for external services."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GDRIVE_SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+
+
+class AuthError(Exception):
+    """Raised when an authentication flow fails."""
+
+
+def run_gdrive_auth(client_credentials_path: str) -> str:
+    """Run the Google Drive OAuth2 authorization flow.
+
+    Opens a browser for the user to authorize read-only Drive access.
+    Returns a JSON string containing the OAuth2 credentials (including
+    a refresh token) suitable for storing as an environment variable.
+
+    Args:
+        client_credentials_path: Path to the ``client_secret.json`` file
+            downloaded from Google Cloud Console.
+
+    Returns:
+        JSON string with the serialized OAuth2 credentials.
+
+    Raises:
+        AuthError: If the credentials file is invalid, missing, or the
+            authorization flow is cancelled/fails.
+    """
+    from google_auth_oauthlib.flow import InstalledAppFlow
+
+    credentials_file = Path(client_credentials_path)
+    if not credentials_file.is_file():
+        msg = f"Client credentials file not found: {client_credentials_path}"
+        raise AuthError(msg)
+
+    try:
+        flow = InstalledAppFlow.from_client_secrets_file(
+            str(credentials_file),
+            scopes=_GDRIVE_SCOPES,
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        msg = f"Invalid client credentials file: {exc}"
+        raise AuthError(msg) from exc
+
+    logger.info("Opening browser for Google Drive authorization...")
+
+    try:
+        credentials = flow.run_local_server(port=0)
+    except Exception as exc:
+        msg = f"Authorization flow failed: {exc}"
+        raise AuthError(msg) from exc
+
+    token_data = {
+        "token": credentials.token,
+        "refresh_token": credentials.refresh_token,
+        "token_uri": credentials.token_uri,
+        "client_id": credentials.client_id,
+        "client_secret": credentials.client_secret,
+        "scopes": list(credentials.scopes) if credentials.scopes else _GDRIVE_SCOPES,
+    }
+
+    return json.dumps(token_data)

--- a/src/receipt_index/cli.py
+++ b/src/receipt_index/cli.py
@@ -5,61 +5,164 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 import click
+from dotenv import load_dotenv
+
+from receipt_index.config import AppConfig, ConfigError, load_config
+
+# Load .env before any config interpolation
+load_dotenv()
 
 if TYPE_CHECKING:
     from datetime import datetime
     from decimal import Decimal
 
+    from receipt_index.adapters.base import SourceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def _load_config_or_exit(ctx: click.Context) -> AppConfig:
+    """Load AppConfig from Click context, exiting with a clear message on error."""
+    config_path: str | None = ctx.obj.get("config_path") if ctx.obj else None
+    try:
+        return load_config(config_path)
+    except ConfigError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
 
 @click.group()
-def cli() -> None:
-    """Receipt Search Index — find receipts fast."""
-    from receipt_index.config import get_log_level
-
-    logging.basicConfig(
-        level=getattr(logging, get_log_level(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=False),
+    default=None,
+    envvar="RECEIPT_INDEX_CONFIG",
+    help="Path to YAML config file.",
+)
+@click.pass_context
+def cli(ctx: click.Context, config_path: str | None) -> None:
+    """Receipt Search Index -- find receipts fast."""
+    ctx.ensure_object(dict)
+    ctx.obj["config_path"] = config_path
 
 
 @cli.command()
+@click.option(
+    "--source",
+    "source_name",
+    default=None,
+    help="Ingest from a specific named source only.",
+)
 @click.option("--dry-run", is_flag=True, help="Preview without processing.")
 @click.option("--limit", type=int, default=None, help="Max messages to process.")
-def ingest(dry_run: bool, limit: int | None) -> None:
+@click.pass_context
+def ingest(
+    ctx: click.Context,
+    source_name: str | None,
+    dry_run: bool,
+    limit: int | None,
+) -> None:
     """Ingest receipts from configured sources."""
     from receipt_index.adapters.imap import ImapAdapter
-    from receipt_index.config import get_imap_config, get_store_path
+    from receipt_index.config import GdriveSourceConfig, ImapSourceConfig
     from receipt_index.db import get_connection
-    from receipt_index.pipeline import run_ingest
+    from receipt_index.extraction import create_extraction_agent
+    from receipt_index.pipeline import IngestResult, run_ingest
     from receipt_index.store import LocalFileStore
 
-    adapter = ImapAdapter(get_imap_config())
-    store = LocalFileStore(get_store_path())
+    config = _load_config_or_exit(ctx)
 
-    with get_connection() as conn:
-        result = run_ingest(
-            conn=conn,
-            adapter=adapter,
-            store=store,
-            dry_run=dry_run,
-            limit=limit,
-        )
-
-    click.echo(
-        f"Processed: {result.processed}  "
-        f"Skipped: {result.skipped}  "
-        f"Failed: {result.failed}"
+    # Configure logging from config
+    logging.basicConfig(
+        level=getattr(logging, config.logging.level, logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    if result.failed > 0:
+    # Filter sources if --source is specified
+    sources = config.sources
+    if source_name is not None:
+        sources = [s for s in sources if s.name == source_name]
+        if not sources:
+            available = ", ".join(s.name for s in config.sources)
+            click.echo(
+                f"Error: source {source_name!r} not found in config. "
+                f"Available sources: {available}",
+                err=True,
+            )
+            sys.exit(1)
+
+    store = LocalFileStore(Path(config.store.path).resolve())
+
+    # Create extraction agent once for all sources
+    agent = create_extraction_agent(
+        api_key=config.llm.api_key,
+        model=config.llm.model,
+    )
+
+    totals = IngestResult()
+    source_results: list[tuple[str, IngestResult]] = []
+
+    for source_config in sources:
+        if isinstance(source_config, ImapSourceConfig):
+            adapter: SourceAdapter = ImapAdapter(source_config)
+        elif isinstance(source_config, GdriveSourceConfig):
+            from receipt_index.adapters.gdrive import GdriveAdapter
+
+            adapter = GdriveAdapter(source_config)
+        else:
+            logger.warning("Unknown source type, skipping %r", source_config.name)
+            continue
+
+        with get_connection(config.database.url) as conn:
+            result = run_ingest(
+                conn=conn,
+                adapter=adapter,
+                store=store,
+                source_name=source_config.name,
+                source_type=source_config.type,
+                agent=agent,
+                dry_run=dry_run,
+                limit=limit,
+            )
+
+            source_results.append((source_config.name, result))
+            totals.processed += result.processed
+            totals.skipped += result.skipped
+            totals.failed += result.failed
+
+    # Report per-source summaries when multiple sources
+    if len(source_results) > 1:
+        for name, result in source_results:
+            click.echo(
+                f"Source {name}: "
+                f"Processed: {result.processed}  "
+                f"Skipped: {result.skipped}  "
+                f"Failed: {result.failed}"
+            )
+        click.echo(
+            f"Total: Processed: {totals.processed}  "
+            f"Skipped: {totals.skipped}  "
+            f"Failed: {totals.failed}"
+        )
+    else:
+        click.echo(
+            f"Processed: {totals.processed}  "
+            f"Skipped: {totals.skipped}  "
+            f"Failed: {totals.failed}"
+        )
+
+    if totals.failed > 0:
         sys.exit(1)
 
 
 @cli.command()
+@click.option("--source", "source_name", default=None, help="Filter by source name.")
 @click.option("--vendor", default=None, help="Filter by vendor name (substring).")
 @click.option("--amount", default=None, help="Filter by exact amount.")
 @click.option("--amount-min", default=None, help="Filter by minimum amount.")
@@ -83,7 +186,10 @@ def ingest(dry_run: bool, limit: int | None) -> None:
     default="text",
     help="Output format.",
 )
+@click.pass_context
 def search(
+    ctx: click.Context,
+    source_name: str | None,
     vendor: str | None,
     amount: str | None,
     amount_min: str | None,
@@ -97,6 +203,13 @@ def search(
 
     from receipt_index.db import get_connection
     from receipt_index.repository import search_receipts
+
+    config = _load_config_or_exit(ctx)
+
+    logging.basicConfig(
+        level=getattr(logging, config.logging.level, logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
 
     if amount is not None and (amount_min is not None or amount_max is not None):
         raise click.UsageError(
@@ -116,7 +229,7 @@ def search(
     amount_min_d = _to_decimal(amount_min, "--amount-min")
     amount_max_d = _to_decimal(amount_max, "--amount-max")
 
-    with get_connection() as conn:
+    with get_connection(config.database.url) as conn:
         results = search_receipts(
             conn,
             vendor=vendor,
@@ -125,6 +238,7 @@ def search(
             amount_max=amount_max_d,
             date_from=date_from.date() if date_from else None,
             date_to=date_to.date() if date_to else None,
+            source_name=source_name,
         )
 
     if output_format == "json":
@@ -137,11 +251,13 @@ def search(
         click.echo(f"{'ID':<38} {'Date':<12} {'Vendor':<20} {'Amount':>10}")
         click.echo("-" * 82)
         for r in results:
-            vendor = r.vendor[:19] + "…" if len(r.vendor) > 20 else r.vendor
+            vendor_display = (
+                r.vendor[:19] + "\u2026" if len(r.vendor) > 20 else r.vendor
+            )
             click.echo(
                 f"{r.id!s:<38} "
                 f"{r.receipt_date.isoformat():<12} "
-                f"{vendor:<20} "
+                f"{vendor_display:<20} "
                 f"{r.amount!s:>10}"
             )
         click.echo(f"\n{len(results)} receipt(s) found.")
@@ -155,12 +271,20 @@ def search(
     default="text",
     help="Output format.",
 )
-def failures(output_format: str) -> None:
+@click.pass_context
+def failures(ctx: click.Context, output_format: str) -> None:
     """List failed ingest attempts."""
     from receipt_index.db import get_connection
     from receipt_index.repository import get_ingest_failures
 
-    with get_connection() as conn:
+    config = _load_config_or_exit(ctx)
+
+    logging.basicConfig(
+        level=getattr(logging, config.logging.level, logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    with get_connection(config.database.url) as conn:
         results = get_ingest_failures(conn)
 
     if output_format == "json":
@@ -174,11 +298,11 @@ def failures(output_format: str) -> None:
         click.echo("-" * 124)
         for r in results:
             email_date = (
-                r.email_date.strftime("%Y-%m-%d %H:%M") if r.email_date else "—"
+                r.email_date.strftime("%Y-%m-%d %H:%M") if r.email_date else "\u2014"
             )
-            sender = (r.email_sender or "—")[:29]
-            subject = (r.email_subject or "—")[:39]
-            error = (r.error_message or "—")[:29]
+            sender = (r.email_sender or "\u2014")[:29]
+            subject = (r.email_subject or "\u2014")[:39]
+            error = (r.error_message or "\u2014")[:29]
             click.echo(f"{email_date:<22} {sender:<30} {subject:<40} {error:<30}")
         click.echo(f"\n{len(results)} failed ingest(s).")
 
@@ -192,10 +316,18 @@ def failures(output_format: str) -> None:
     default="text",
     help="Output format.",
 )
-def show(receipt_id: str, output_format: str) -> None:
+@click.pass_context
+def show(ctx: click.Context, receipt_id: str, output_format: str) -> None:
     """Show details for a specific receipt."""
     from receipt_index.db import get_connection
     from receipt_index.repository import get_receipt_by_id
+
+    config = _load_config_or_exit(ctx)
+
+    logging.basicConfig(
+        level=getattr(logging, config.logging.level, logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
 
     try:
         uid = UUID(receipt_id)
@@ -203,7 +335,7 @@ def show(receipt_id: str, output_format: str) -> None:
         click.echo(f"Error: invalid UUID: {receipt_id}", err=True)
         sys.exit(1)
 
-    with get_connection() as conn:
+    with get_connection(config.database.url) as conn:
         receipt = get_receipt_by_id(conn, uid)
 
     if receipt is None:
@@ -217,13 +349,54 @@ def show(receipt_id: str, output_format: str) -> None:
         click.echo(f"Vendor:       {receipt.vendor}")
         click.echo(f"Amount:       {receipt.amount} {receipt.currency}")
         click.echo(f"Date:         {receipt.receipt_date}")
-        click.echo(f"Description:  {receipt.description or '—'}")
+        desc = receipt.description or "\u2014"
+        click.echo(f"Description:  {desc}")
         click.echo(f"Confidence:   {receipt.confidence}")
         click.echo(f"PDF:          {receipt.pdf_path}")
         click.echo(f"Source:       {receipt.source_type} ({receipt.source_id})")
+        if receipt.source_name:
+            click.echo(f"Source Name:  {receipt.source_name}")
         if receipt.email_subject:
             click.echo(f"Subject:      {receipt.email_subject}")
         if receipt.email_sender:
             click.echo(f"Sender:       {receipt.email_sender}")
         if receipt.email_date:
             click.echo(f"Email Date:   {receipt.email_date.isoformat()}")
+        if receipt.file_name:
+            click.echo(f"File:         {receipt.file_name}")
+
+
+@cli.group()
+def auth() -> None:
+    """Manage authentication for external services."""
+
+
+@auth.command()
+@click.option(
+    "--client-credentials",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to Google OAuth2 client_secret.json file.",
+)
+def gdrive(client_credentials: str) -> None:
+    """Authorize Google Drive access (one-time setup).
+
+    Opens a browser for OAuth2 authorization, then outputs the token
+    JSON for storing as the GDRIVE_TOKEN_JSON environment variable.
+    """
+    from receipt_index.auth import AuthError, run_gdrive_auth
+
+    try:
+        token_json = run_gdrive_auth(client_credentials)
+    except AuthError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo("\nAuthorization successful. Token JSON:\n")
+    click.echo(token_json)
+    click.echo(
+        "\nStore this value as the GDRIVE_TOKEN_JSON environment variable."
+        "\nFor example, add to your .env file:"
+        "\n"
+        f"\n  GDRIVE_TOKEN_JSON='{token_json}'"
+    )

--- a/src/receipt_index/cli.py
+++ b/src/receipt_index/cli.py
@@ -99,10 +99,17 @@ def ingest(
 
     store = LocalFileStore(Path(config.store.path).resolve())
 
-    # Create extraction agent once for all sources
-    agent = create_extraction_agent(
+    # Create extraction agents — email and document prompts differ
+    from receipt_index.extraction import DOCUMENT_SYSTEM_PROMPT
+
+    email_agent = create_extraction_agent(
         api_key=config.llm.api_key,
         model=config.llm.model,
+    )
+    document_agent = create_extraction_agent(
+        api_key=config.llm.api_key,
+        model=config.llm.model,
+        system_prompt=DOCUMENT_SYSTEM_PROMPT,
     )
 
     totals = IngestResult()
@@ -111,10 +118,12 @@ def ingest(
     for source_config in sources:
         if isinstance(source_config, ImapSourceConfig):
             adapter: SourceAdapter = ImapAdapter(source_config)
+            agent = email_agent
         elif isinstance(source_config, GdriveSourceConfig):
             from receipt_index.adapters.gdrive import GdriveAdapter
 
             adapter = GdriveAdapter(source_config)
+            agent = document_agent
         else:
             logger.warning("Unknown source type, skipping %r", source_config.name)
             continue

--- a/src/receipt_index/config.py
+++ b/src/receipt_index/config.py
@@ -1,110 +1,318 @@
-"""Configuration via environment variables."""
+"""YAML-based application configuration with env var interpolation.
+
+Config file search order (first found wins):
+1. Explicit path via ``config_path`` argument or ``--config`` CLI flag
+2. ``RECEIPT_INDEX_CONFIG`` environment variable
+3. ``./receipt-index.yaml`` (current working directory)
+4. ``~/.config/receipt-index/config.yaml`` (XDG convention)
+"""
 
 from __future__ import annotations
 
+import logging
 import os
-from dataclasses import dataclass
+import re
 from pathlib import Path
+from typing import Annotated, Any, Literal
 
-from dotenv import load_dotenv
+import yaml
+from pydantic import BaseModel, Discriminator, Field, Tag, ValidationError
 
-load_dotenv()
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+_ENV_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+_EXAMPLE_CONFIG = """\
+# receipt-index.yaml
+sources:
+  - name: personal-email
+    type: imap
+    host: mail.example.com
+    port: 993
+    username: user@example.com
+    password: ${IMAP_PASSWORD}
+    folder: INBOX.Receipts
+    use_ssl: true
+
+database:
+  url: ${DATABASE_URL}
+
+store:
+  path: ./data/receipts
+
+llm:
+  model: claude-haiku-4-5-20251001
+  api_key: ${ANTHROPIC_API_KEY}
+
+logging:
+  level: INFO
+"""
 
 
-@dataclass(frozen=True)
-class ImapConfig:
-    """IMAP connection configuration."""
+class ConfigError(Exception):
+    """Raised when configuration loading fails."""
 
+
+# ---------------------------------------------------------------------------
+# Config models
+# ---------------------------------------------------------------------------
+
+
+class ImapSourceConfig(BaseModel):
+    """IMAP email source configuration."""
+
+    name: str = Field(min_length=1, pattern=r"^[a-z0-9][a-z0-9-]*$")
+    type: Literal["imap"] = "imap"
     host: str
+    port: int = 993
     username: str
     password: str
-    port: int = 993
     folder: str = "INBOX"
     use_ssl: bool = True
 
 
-def get_database_url() -> str:
-    """Return the DATABASE_URL from the environment."""
-    url = os.environ.get("DATABASE_URL")
-    if not url:
-        msg = "DATABASE_URL environment variable is required"
-        raise ValueError(msg)
-    return url
+class GdriveSourceConfig(BaseModel):
+    """Google Drive source configuration."""
+
+    name: str = Field(min_length=1, pattern=r"^[a-z0-9][a-z0-9-]*$")
+    type: Literal["gdrive"] = "gdrive"
+    folder_id: str
+    credentials_json: str
+    token_json: str
 
 
-def get_store_path() -> Path:
-    """Return the RECEIPT_STORE_PATH, defaulting to ./data/receipts.
+def _source_discriminator(v: Any) -> str:
+    """Discriminate source config union by the ``type`` field."""
+    if isinstance(v, dict):
+        return str(v.get("type", ""))
+    return str(getattr(v, "type", ""))
 
-    Always resolves to an absolute path to avoid issues if the
-    working directory changes during execution.
+
+SourceConfig = Annotated[
+    Annotated[ImapSourceConfig, Tag("imap")]
+    | Annotated[GdriveSourceConfig, Tag("gdrive")],
+    Discriminator(_source_discriminator),
+]
+
+
+class DatabaseConfig(BaseModel):
+    """Database connection configuration."""
+
+    url: str
+
+
+class StoreConfig(BaseModel):
+    """File store configuration."""
+
+    path: str = "./data/receipts"
+
+
+class LlmConfig(BaseModel):
+    """LLM provider configuration."""
+
+    model: str = "claude-haiku-4-5-20251001"
+    api_key: str
+
+
+class LoggingConfig(BaseModel):
+    """Logging configuration."""
+
+    level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+
+
+class AppConfig(BaseModel):
+    """Top-level application configuration."""
+
+    sources: list[SourceConfig]
+    database: DatabaseConfig
+    store: StoreConfig = StoreConfig(path="./data/receipts")
+    llm: LlmConfig
+    logging: LoggingConfig = LoggingConfig()
+
+
+# ---------------------------------------------------------------------------
+# Env var interpolation
+# ---------------------------------------------------------------------------
+
+
+def _interpolate_env_value(value: str) -> str:
+    """Replace ``${VAR}`` patterns in a string with environment variable values.
+
+    Raises :class:`ConfigError` if a referenced variable is not set.
     """
-    return Path(os.environ.get("RECEIPT_STORE_PATH", "./data/receipts")).resolve()
+    missing: list[str] = []
 
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        val = os.environ.get(var)
+        if val is None:
+            missing.append(var)
+            return match.group(0)  # preserve original for error reporting
+        return val
 
-def get_imap_config() -> ImapConfig:
-    """Build IMAP configuration from environment variables.
-
-    Required: IMAP_HOST, IMAP_USERNAME, IMAP_PASSWORD
-    Optional: IMAP_PORT (default 993), IMAP_FOLDER (default INBOX),
-              IMAP_USE_SSL (default true)
-    """
-    host = os.environ.get("IMAP_HOST")
-    username = os.environ.get("IMAP_USERNAME")
-    password = os.environ.get("IMAP_PASSWORD")
-
-    missing = []
-    if not host:
-        missing.append("IMAP_HOST")
-    if not username:
-        missing.append("IMAP_USERNAME")
-    if not password:
-        missing.append("IMAP_PASSWORD")
-
+    result = _ENV_PATTERN.sub(_replace, value)
     if missing:
-        msg = f"Required environment variables not set: {', '.join(missing)}"
-        raise ValueError(msg)
+        raise ConfigError(f"Environment variable(s) not set: {', '.join(missing)}")
+    return result
 
-    port_str = os.environ.get("IMAP_PORT", "993")
-    port = int(port_str)
 
-    folder = os.environ.get("IMAP_FOLDER", "INBOX")
-    use_ssl = os.environ.get("IMAP_USE_SSL", "true").lower() in ("true", "1", "yes")
+def _interpolate_env_vars(data: Any) -> Any:
+    """Recursively walk a parsed YAML structure and interpolate env vars.
 
-    return ImapConfig(
-        host=host,  # type: ignore[arg-type]
-        username=username,  # type: ignore[arg-type]
-        password=password,  # type: ignore[arg-type]
-        port=port,
-        folder=folder,
-        use_ssl=use_ssl,
+    Collects *all* missing env var names across the entire config and raises
+    a single :class:`ConfigError` listing them all.
+    """
+    all_missing: list[str] = []
+
+    def _walk(node: Any) -> Any:
+        if isinstance(node, str):
+            try:
+                return _interpolate_env_value(node)
+            except ConfigError as exc:
+                msg = str(exc)
+                if "not set:" in msg:
+                    vars_str = msg.split("not set:", 1)[1].strip()
+                    all_missing.extend(v.strip() for v in vars_str.split(","))
+                return node
+        if isinstance(node, dict):
+            return {k: _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(item) for item in node]
+        return node
+
+    result = _walk(data)
+    if all_missing:
+        seen: set[str] = set()
+        unique: list[str] = []
+        for var in all_missing:
+            if var not in seen:
+                seen.add(var)
+                unique.append(var)
+        raise ConfigError(f"Environment variable(s) not set: {', '.join(unique)}")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+def load_config_dict(yaml_content: str) -> dict[str, Any]:
+    """Parse a YAML string, interpolate env vars, and return the raw dict.
+
+    This is the low-level loader used by :func:`load_config`. It does not
+    perform Pydantic validation.
+    """
+    try:
+        data = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML syntax: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError("Config file must contain a YAML mapping at the top level")
+    return _interpolate_env_vars(data)  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Config file discovery
+# ---------------------------------------------------------------------------
+
+
+def _find_config_file() -> Path | None:
+    """Search for a config file in the standard locations.
+
+    Returns the first existing file path, or ``None`` if no config is found.
+    """
+    # 1. RECEIPT_INDEX_CONFIG env var
+    env_path = os.environ.get("RECEIPT_INDEX_CONFIG")
+    if env_path:
+        path = Path(env_path).expanduser()
+        if path.is_file():
+            logger.debug("Config found via RECEIPT_INDEX_CONFIG: %s", path)
+            return path
+        raise ConfigError(
+            f"RECEIPT_INDEX_CONFIG points to '{env_path}' but the file does not exist"
+        )
+
+    # 2. ./receipt-index.yaml
+    cwd_path = Path.cwd() / "receipt-index.yaml"
+    if cwd_path.is_file():
+        logger.debug("Config found in current directory: %s", cwd_path)
+        return cwd_path
+
+    # 3. ~/.config/receipt-index/config.yaml
+    xdg_path = Path.home() / ".config" / "receipt-index" / "config.yaml"
+    if xdg_path.is_file():
+        logger.debug("Config found at XDG location: %s", xdg_path)
+        return xdg_path
+
+    return None
+
+
+def _config_not_found_message() -> str:
+    """Build a helpful error message when no config file is found."""
+    locations = [
+        "  1. --config CLI flag or config_path argument",
+        "  2. RECEIPT_INDEX_CONFIG environment variable",
+        "  3. ./receipt-index.yaml (current directory)",
+        "  4. ~/.config/receipt-index/config.yaml",
+    ]
+    return (
+        "No configuration file found. Searched:\n"
+        + "\n".join(locations)
+        + "\n\nCreate a config file with the following structure:\n\n"
+        + _EXAMPLE_CONFIG
     )
 
 
-def get_anthropic_api_key() -> str:
-    """Return the ANTHROPIC_API_KEY from the environment."""
-    key = os.environ.get("ANTHROPIC_API_KEY")
-    if not key:
-        msg = "ANTHROPIC_API_KEY environment variable is required"
-        raise ValueError(msg)
-    return key
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
-def get_llm_model() -> str:
-    """Return the LLM model identifier.
+def load_config(config_path: str | None = None) -> AppConfig:
+    """Load and validate the application configuration.
 
-    Defaults to claude-haiku-4-5-20251001.
+    Parameters
+    ----------
+    config_path:
+        Explicit path to a YAML config file. If provided, this takes
+        precedence over all other search locations.
+
+    Returns
+    -------
+    AppConfig
+        The fully validated application configuration.
+
+    Raises
+    ------
+    ConfigError
+        If no config file is found, the file cannot be read, env vars are
+        missing, or validation fails.
     """
-    return os.environ.get("LLM_MODEL", "claude-haiku-4-5-20251001")
+    path: Path
+    if config_path is not None:
+        path = Path(config_path).expanduser()
+        if not path.is_file():
+            raise ConfigError(f"Config file not found: {config_path}")
+    else:
+        found = _find_config_file()
+        if found is None:
+            raise ConfigError(_config_not_found_message())
+        path = found
 
+    logger.info("Loading config from %s", path)
+    try:
+        yaml_content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigError(f"Cannot read config file: {exc}") from exc
 
-_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    config_dict = load_config_dict(yaml_content)
 
-
-def get_log_level() -> str:
-    """Return the log level from LOG_LEVEL env var, defaulting to INFO."""
-    level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    if level not in _VALID_LOG_LEVELS:
-        valid = sorted(_VALID_LOG_LEVELS)
-        msg = f"Invalid LOG_LEVEL: {level!r}. Must be one of {valid}"
-        raise ValueError(msg)
-    return level
+    try:
+        return AppConfig.model_validate(config_dict)
+    except ValidationError as exc:
+        raise ConfigError(f"Config validation failed:\n{exc}") from exc

--- a/src/receipt_index/config.py
+++ b/src/receipt_index/config.py
@@ -81,7 +81,6 @@ class GdriveSourceConfig(BaseModel):
     name: str = Field(min_length=1, pattern=r"^[a-z0-9][a-z0-9-]*$")
     type: Literal["gdrive"] = "gdrive"
     folder_id: str
-    credentials_json: str
     token_json: str
 
 
@@ -186,12 +185,7 @@ def _interpolate_env_vars(data: Any) -> Any:
 
     result = _walk(data)
     if all_missing:
-        seen: set[str] = set()
-        unique: list[str] = []
-        for var in all_missing:
-            if var not in seen:
-                seen.add(var)
-                unique.append(var)
+        unique = list(dict.fromkeys(all_missing))
         raise ConfigError(f"Environment variable(s) not set: {', '.join(unique)}")
     return result
 

--- a/src/receipt_index/db.py
+++ b/src/receipt_index/db.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import psycopg
 from psycopg.rows import dict_row
 
-from receipt_index.config import get_database_url
 
+def get_connection(database_url: str) -> psycopg.Connection[dict[str, object]]:
+    """Create and return a new database connection.
 
-def get_connection() -> psycopg.Connection[dict[str, object]]:
-    """Create and return a new database connection."""
-    return psycopg.connect(get_database_url(), row_factory=dict_row)
+    Parameters
+    ----------
+    database_url:
+        PostgreSQL connection URL.
+    """
+    return psycopg.connect(database_url, row_factory=dict_row)

--- a/src/receipt_index/extraction.py
+++ b/src/receipt_index/extraction.py
@@ -6,9 +6,8 @@ import logging
 from html.parser import HTMLParser
 from typing import Any
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, BinaryContent
 
-from receipt_index.config import get_anthropic_api_key, get_llm_model
 from receipt_index.models import Attachment, RawReceipt, ReceiptMetadata
 
 logger = logging.getLogger(__name__)
@@ -34,17 +33,45 @@ For multi-item orders, use the total amount. If the currency is not stated, \
 assume USD.\
 """
 
+_DOCUMENT_SYSTEM_PROMPT = """\
+You are a receipt metadata extractor. Given a receipt document (scanned image \
+or PDF), extract the following fields:
 
-def create_extraction_agent() -> Agent[None, ReceiptMetadata]:
+- vendor: The business name on the receipt (or payment recipient)
+- amount: The total amount charged (numeric, e.g. 42.99). May be 0 for \
+prepaid items (e.g. prepaid postage).
+- currency: ISO 4217 currency code (e.g. "USD")
+- date: The transaction date (YYYY-MM-DD)
+- description: Brief summary of what was purchased (optional)
+- confidence: Your confidence in the extraction from 0.0 to 1.0. \
+Use below 0.5 if this does not appear to be a receipt or key fields are unclear.
+
+Payment confirmations (Zelle, Venmo, PayPal, bank transfers, wire transfers) \
+are valid receipts. The vendor is the payment recipient. Use high confidence \
+if the amount, recipient, and date are clearly visible.
+
+For multi-item receipts, use the total amount. If the currency is not stated, \
+assume USD.\
+"""
+
+# Minimum non-whitespace characters for PDF text to be considered sufficient.
+# Matches the threshold used in pdf_reader.py.
+_MIN_TEXT_LENGTH = 20
+
+_IMAGE_CONTENT_TYPES = frozenset({"image/jpeg", "image/png"})
+
+
+def create_extraction_agent(
+    *,
+    api_key: str,
+    model: str,
+    system_prompt: str = _SYSTEM_PROMPT,
+) -> Agent[None, ReceiptMetadata]:
     """Create a pydantic-ai Agent configured for receipt extraction."""
-    # Ensure API key is available (fail fast)
-    get_anthropic_api_key()
-
-    model_name = get_llm_model()
     return Agent(
-        f"anthropic:{model_name}",
+        f"anthropic:{model}",
         output_type=ReceiptMetadata,
-        system_prompt=_SYSTEM_PROMPT,
+        system_prompt=system_prompt,
     )
 
 
@@ -53,17 +80,119 @@ def extract_metadata(
     *,
     agent: Agent[None, ReceiptMetadata] | None = None,
 ) -> ReceiptMetadata:
-    """Extract structured metadata from a raw receipt email.
+    """Extract structured metadata from a raw receipt.
+
+    Routes to the appropriate extraction path based on ``raw.source_type``:
+    - ``"gdrive"``: document-based extraction (vision or PDF text)
+    - Otherwise: email-based extraction (existing path)
 
     Accepts an optional agent for dependency injection in tests.
     """
+    if raw.source_type == "gdrive":
+        return _extract_from_document(raw, agent=agent)
+    return _extract_from_email(raw, agent=agent)
+
+
+def _extract_from_email(
+    raw: RawReceipt,
+    *,
+    agent: Agent[None, ReceiptMetadata] | None = None,
+) -> ReceiptMetadata:
+    """Extract metadata from an email-sourced receipt."""
     if agent is None:
-        agent = create_extraction_agent()
+        msg = "No extraction agent provided."
+        raise ValueError(msg)
 
     pdf_text = _extract_pdf_text(raw.attachments)
     prompt = _build_prompt(raw, pdf_text=pdf_text)
     result: Any = agent.run_sync(prompt)
     return result.output  # type: ignore[no-any-return]
+
+
+def _extract_from_document(
+    raw: RawReceipt,
+    *,
+    agent: Agent[None, ReceiptMetadata] | None = None,
+) -> ReceiptMetadata:
+    """Extract metadata from a Drive-sourced document (PDF or image).
+
+    For PDFs: extract text first; if insufficient, fall back to vision.
+    For images: send directly to the LLM as image input.
+    """
+    if agent is None:
+        msg = "No extraction agent provided."
+        raise ValueError(msg)
+
+    if raw.file_content is None:
+        raise ValueError("Drive-sourced receipt has no file_content")
+
+    content_type = (raw.file_content_type or "").lower()
+
+    if content_type == "application/pdf":
+        return _extract_from_pdf_document(raw.file_content, agent=agent)
+
+    if content_type in _IMAGE_CONTENT_TYPES:
+        return _extract_from_image(raw.file_content, content_type, agent=agent)
+
+    raise ValueError(
+        f"Unsupported file content type for document extraction: {content_type!r}"
+    )
+
+
+def _extract_from_pdf_document(
+    pdf_bytes: bytes,
+    *,
+    agent: Agent[None, ReceiptMetadata],
+) -> ReceiptMetadata:
+    """Extract metadata from a PDF document.
+
+    Tries text extraction first. If the text is insufficient (< 20 non-whitespace
+    chars), falls back to sending the PDF as binary content for vision analysis.
+    """
+    from receipt_index.pdf_reader import extract_text
+
+    text = extract_text(pdf_bytes)
+
+    if _has_sufficient_text(text):
+        logger.debug("Using text-based extraction for PDF (%d chars)", len(text))
+        result: Any = agent.run_sync(
+            f"Extract receipt metadata from this document text:\n\n{text}"
+        )
+        return result.output  # type: ignore[no-any-return]
+
+    logger.info(
+        "PDF text extraction insufficient (%d non-ws chars), using vision",
+        len("".join(text.split())),
+    )
+    result = agent.run_sync(
+        [
+            "Extract receipt metadata from this PDF document.",
+            BinaryContent(data=pdf_bytes, media_type="application/pdf"),
+        ]
+    )
+    return result.output  # type: ignore[no-any-return]
+
+
+def _extract_from_image(
+    image_data: bytes,
+    content_type: str,
+    *,
+    agent: Agent[None, ReceiptMetadata],
+) -> ReceiptMetadata:
+    """Extract metadata from an image file by sending it to the LLM via vision."""
+    result: Any = agent.run_sync(
+        [
+            "Extract receipt metadata from this receipt image.",
+            BinaryContent(data=image_data, media_type=content_type),
+        ]
+    )
+    return result.output  # type: ignore[no-any-return]
+
+
+def _has_sufficient_text(text: str) -> bool:
+    """Check if extracted text meets the minimum quality threshold."""
+    stripped = "".join(text.split())
+    return len(stripped) >= _MIN_TEXT_LENGTH
 
 
 def _build_prompt(raw: RawReceipt, *, pdf_text: str | None = None) -> str:

--- a/src/receipt_index/extraction.py
+++ b/src/receipt_index/extraction.py
@@ -33,7 +33,7 @@ For multi-item orders, use the total amount. If the currency is not stated, \
 assume USD.\
 """
 
-_DOCUMENT_SYSTEM_PROMPT = """\
+DOCUMENT_SYSTEM_PROMPT = """\
 You are a receipt metadata extractor. Given a receipt document (scanned image \
 or PDF), extract the following fields:
 

--- a/src/receipt_index/image_converter.py
+++ b/src/receipt_index/image_converter.py
@@ -1,0 +1,47 @@
+"""Image-to-PDF conversion for receipt files."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_FORMATS = {"JPEG", "PNG"}
+
+
+def image_to_pdf(image_data: bytes) -> bytes:
+    """Convert image bytes (JPEG, PNG) to PDF bytes.
+
+    Args:
+        image_data: Raw image file bytes.
+
+    Returns:
+        PDF file bytes containing the image.
+
+    Raises:
+        ValueError: If the image format is not supported or the data
+            cannot be decoded as an image.
+    """
+    try:
+        img = Image.open(io.BytesIO(image_data))
+    except Exception as exc:
+        raise ValueError("Unable to decode image data") from exc
+
+    fmt = img.format
+    if fmt not in _SUPPORTED_FORMATS:
+        raise ValueError(
+            f"Unsupported image format {fmt!r}; expected one of {_SUPPORTED_FORMATS}"
+        )
+
+    # PDF does not support alpha channel — convert RGBA to RGB.
+    output_img: Image.Image = img
+    if img.mode in ("RGBA", "LA", "PA"):
+        logger.debug("Converting %s image from %s to RGB", fmt, img.mode)
+        output_img = img.convert("RGB")
+
+    buf = io.BytesIO()
+    output_img.save(buf, format="PDF")
+    return buf.getvalue()

--- a/src/receipt_index/models.py
+++ b/src/receipt_index/models.py
@@ -22,22 +22,33 @@ class Attachment:
 
 @dataclass
 class RawReceipt:
-    """Raw receipt data from a source adapter."""
+    """Raw receipt data from a source adapter.
+
+    Supports both email-based (IMAP) and file-based (Google Drive) sources.
+    Email fields (subject, sender, html_body, text_body, attachments) are used
+    by the IMAP adapter. File fields (file_name, file_content, file_content_type)
+    are used by the Drive adapter.
+    """
 
     source_id: str
-    subject: str
-    sender: str
+    source_name: str
+    source_type: str
     date: datetime
+    subject: str = ""
+    sender: str = ""
     html_body: str | None = None
     text_body: str | None = None
     attachments: list[Attachment] = field(default_factory=list)
+    file_name: str | None = None
+    file_content: bytes | None = None
+    file_content_type: str | None = None
 
 
 class ReceiptMetadata(BaseModel):
     """Structured metadata extracted from a receipt by the LLM."""
 
     vendor: str = Field(min_length=1)
-    amount: Decimal = Field(gt=0)
+    amount: Decimal = Field(ge=0)
     currency: str = Field(default="USD", pattern=r"^[A-Z]{3}$")
     date: date
     description: str | None = None
@@ -50,6 +61,7 @@ class Receipt(BaseModel):
     id: UUID
     source_id: str
     source_type: str
+    source_name: str
     vendor: str
     amount: Decimal
     currency: str
@@ -60,6 +72,7 @@ class Receipt(BaseModel):
     email_subject: str | None
     email_sender: str | None
     email_date: datetime | None
+    file_name: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/src/receipt_index/pdf_reader.py
+++ b/src/receipt_index/pdf_reader.py
@@ -9,8 +9,6 @@ from typing import Any
 import pdfplumber
 from pydantic_ai import Agent, BinaryContent
 
-from receipt_index.config import get_anthropic_api_key, get_llm_model
-
 logger = logging.getLogger(__name__)
 
 # Minimum non-whitespace characters to consider pdfplumber output valid.
@@ -63,12 +61,26 @@ def extract_text(
     return _extract_with_vision(pdf_bytes, agent=vision_agent)
 
 
-def create_vision_agent() -> Agent[None, str]:
-    """Create a pydantic-ai Agent configured for PDF text extraction."""
-    get_anthropic_api_key()  # Fail fast if missing
-    model_name = get_llm_model()
+def create_vision_agent(
+    *,
+    api_key: str,
+    model: str = "claude-haiku-4-5-20251001",
+) -> Agent[None, str]:
+    """Create a pydantic-ai Agent configured for PDF text extraction.
+
+    Parameters
+    ----------
+    api_key:
+        Anthropic API key.
+    model:
+        Model identifier.
+    """
+    if not api_key:
+        msg = "Anthropic API key is required"
+        raise ValueError(msg)
+
     return Agent(
-        f"anthropic:{model_name}",
+        f"anthropic:{model}",
         output_type=str,
         system_prompt=_VISION_SYSTEM_PROMPT,
     )
@@ -98,7 +110,8 @@ def _extract_with_vision(
 ) -> str:
     """Extract text from PDF using Claude vision API."""
     if agent is None:
-        agent = create_vision_agent()
+        logger.warning("No vision agent provided; skipping vision extraction")
+        return ""
 
     try:
         result: Any = agent.run_sync(

--- a/src/receipt_index/pipeline.py
+++ b/src/receipt_index/pipeline.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_MIN_CONFIDENCE = 0.5
+
 
 @dataclass
 class IngestResult:
@@ -40,6 +42,8 @@ def run_ingest(
     conn: psycopg.Connection[dict[str, Any]],
     adapter: SourceAdapter,
     store: FileStore,
+    source_name: str,
+    source_type: str = "imap",
     agent: Agent[None, ReceiptMetadata] | None = None,
     dry_run: bool = False,
     limit: int | None = None,
@@ -50,6 +54,8 @@ def run_ingest(
     renders PDFs, saves to the file store, and inserts into the database.
     """
     result = IngestResult()
+    # Check all source_ids globally — the UNIQUE constraint is on source_id alone,
+    # so we must skip any ID that exists regardless of source_name.
     processed_ids = get_processed_source_ids(conn)
 
     count = 0
@@ -65,6 +71,34 @@ def run_ingest(
 
         try:
             metadata = extract_metadata(raw, agent=agent)
+
+            # Skip non-receipts based on low LLM confidence only.
+            # amount == 0 is valid (e.g. prepaid postage receipts).
+            if metadata.confidence < _MIN_CONFIDENCE:
+                reason = (
+                    f"amount={metadata.amount}, confidence={metadata.confidence:.2f}"
+                )
+                logger.info(
+                    "Skipped non-receipt %s (%s): %s",
+                    raw.source_id,
+                    raw.subject,
+                    reason,
+                )
+                insert_ingest_log(
+                    conn,
+                    source_id=raw.source_id,
+                    source_type=source_type,
+                    status="skipped",
+                    vendor=metadata.vendor,
+                    amount=metadata.amount,
+                    email_subject=raw.subject,
+                    email_sender=raw.sender,
+                    email_date=raw.date if raw.source_type == "imap" else None,
+                    error_message=f"Skipped: {reason}",
+                )
+                result.skipped += 1
+                continue
+
             pdf_data = render_pdf(raw)
             pdf_path = store.save(
                 metadata.date, metadata.vendor, metadata.amount, pdf_data
@@ -72,7 +106,8 @@ def run_ingest(
             receipt = insert_receipt(
                 conn,
                 source_id=raw.source_id,
-                source_type="imap",
+                source_type=source_type,
+                source_name=source_name,
                 vendor=metadata.vendor,
                 amount=metadata.amount,
                 currency=metadata.currency,
@@ -82,21 +117,21 @@ def run_ingest(
                 pdf_path=pdf_path,
                 email_subject=raw.subject,
                 email_sender=raw.sender,
-                email_date=raw.date,
+                email_date=raw.date if raw.source_type == "imap" else None,
             )
             result.processed += 1
             result.receipts.append(receipt)
             insert_ingest_log(
                 conn,
                 source_id=raw.source_id,
-                source_type="imap",
+                source_type=source_type,
                 status="success",
                 receipt_id=receipt.id,
                 vendor=metadata.vendor,
                 amount=metadata.amount,
                 email_subject=raw.subject,
                 email_sender=raw.sender,
-                email_date=raw.date,
+                email_date=raw.date if raw.source_type == "imap" else None,
             )
             logger.info(
                 "Processed receipt: %s (%s) confidence=%.2f",
@@ -105,15 +140,17 @@ def run_ingest(
                 metadata.confidence,
             )
         except Exception as exc:
+            # Rollback failed transaction so the ingest_log write succeeds
+            conn.rollback()
             try:
                 insert_ingest_log(
                     conn,
                     source_id=raw.source_id,
-                    source_type="imap",
+                    source_type=source_type,
                     status="failed",
                     email_subject=raw.subject,
                     email_sender=raw.sender,
-                    email_date=raw.date,
+                    email_date=raw.date if raw.source_type == "imap" else None,
                     error_message=str(exc),
                 )
             except Exception:

--- a/src/receipt_index/pipeline.py
+++ b/src/receipt_index/pipeline.py
@@ -43,7 +43,7 @@ def run_ingest(
     adapter: SourceAdapter,
     store: FileStore,
     source_name: str,
-    source_type: str = "imap",
+    source_type: str,
     agent: Agent[None, ReceiptMetadata] | None = None,
     dry_run: bool = False,
     limit: int | None = None,
@@ -118,6 +118,7 @@ def run_ingest(
                 email_subject=raw.subject,
                 email_sender=raw.sender,
                 email_date=raw.date if raw.source_type == "imap" else None,
+                file_name=raw.file_name,
             )
             result.processed += 1
             result.receipts.append(receipt)

--- a/src/receipt_index/renderer.py
+++ b/src/receipt_index/renderer.py
@@ -65,7 +65,7 @@ def _render_drive_file(raw: RawReceipt) -> bytes:
     if content_type == "application/pdf":
         return raw.file_content
 
-    if content_type.startswith("image/"):
+    if content_type in {"image/jpeg", "image/png"}:
         from receipt_index.image_converter import image_to_pdf
 
         return image_to_pdf(raw.file_content)

--- a/src/receipt_index/renderer.py
+++ b/src/receipt_index/renderer.py
@@ -1,4 +1,4 @@
-"""Email-to-PDF rendering."""
+"""Receipt-to-PDF rendering."""
 
 from __future__ import annotations
 
@@ -41,6 +41,42 @@ PLAIN_TEXT_TEMPLATE = """\
 
 def render_pdf(raw: RawReceipt) -> bytes:
     """Render a RawReceipt to PDF bytes.
+
+    Routes based on source_type:
+    - "gdrive": return file directly (PDF) or convert image to PDF
+    - Otherwise: email rendering (existing path)
+    """
+    if raw.source_type == "gdrive":
+        return _render_drive_file(raw)
+    return _render_email(raw)
+
+
+def _render_drive_file(raw: RawReceipt) -> bytes:
+    """Render a Drive-sourced file to PDF.
+
+    - PDF files: return content directly (already a PDF).
+    - Image files: convert to PDF via image_to_pdf.
+    """
+    if raw.file_content is None:
+        raise ValueError("Drive-sourced receipt has no file_content")
+
+    content_type = (raw.file_content_type or "").lower()
+
+    if content_type == "application/pdf":
+        return raw.file_content
+
+    if content_type.startswith("image/"):
+        from receipt_index.image_converter import image_to_pdf
+
+        return image_to_pdf(raw.file_content)
+
+    raise ValueError(
+        f"Unsupported file content type for Drive rendering: {content_type!r}"
+    )
+
+
+def _render_email(raw: RawReceipt) -> bytes:
+    """Render an email-sourced receipt to PDF.
 
     Strategy (in order of preference):
     1. If a PDF attachment exists, return it directly

--- a/src/receipt_index/repository.py
+++ b/src/receipt_index/repository.py
@@ -14,9 +14,19 @@ if TYPE_CHECKING:
     import psycopg
 
 
-def get_processed_source_ids(conn: psycopg.Connection[dict[str, Any]]) -> set[str]:
-    """Return the set of source_ids already stored in the database."""
-    cur = conn.execute("SELECT source_id FROM receipt.receipts")
+def get_processed_source_ids(
+    conn: psycopg.Connection[dict[str, Any]],
+) -> set[str]:
+    """Return source_ids already in receipts or ingest_log (skipped/failed).
+
+    This provides full idempotency — we won't re-process messages that were
+    previously ingested, skipped (not a receipt), or failed.
+    """
+    cur = conn.execute(
+        "SELECT source_id FROM receipt.receipts "
+        "UNION "
+        "SELECT source_id FROM receipt.ingest_log"
+    )
     return {str(row["source_id"]) for row in cur.fetchall()}
 
 
@@ -25,6 +35,7 @@ def insert_receipt(
     *,
     source_id: str,
     source_type: str,
+    source_name: str,
     vendor: str,
     amount: Decimal,
     currency: str,
@@ -35,24 +46,27 @@ def insert_receipt(
     email_subject: str | None,
     email_sender: str | None,
     email_date: datetime | None,
+    file_name: str | None = None,
 ) -> Receipt:
     """Insert a receipt row and return the validated Receipt model."""
     cur = conn.execute(
         """\
         INSERT INTO receipt.receipts (
-            source_id, source_type, vendor, amount, currency,
+            source_id, source_type, source_name, vendor, amount, currency,
             receipt_date, description, confidence, pdf_path,
-            email_subject, email_sender, email_date
+            email_subject, email_sender, email_date, file_name
         ) VALUES (
-            %(source_id)s, %(source_type)s, %(vendor)s, %(amount)s, %(currency)s,
+            %(source_id)s, %(source_type)s, %(source_name)s,
+            %(vendor)s, %(amount)s, %(currency)s,
             %(receipt_date)s, %(description)s, %(confidence)s, %(pdf_path)s,
-            %(email_subject)s, %(email_sender)s, %(email_date)s
+            %(email_subject)s, %(email_sender)s, %(email_date)s, %(file_name)s
         )
         RETURNING *
         """,
         {
             "source_id": source_id,
             "source_type": source_type,
+            "source_name": source_name,
             "vendor": vendor,
             "amount": amount,
             "currency": currency,
@@ -63,6 +77,7 @@ def insert_receipt(
             "email_subject": email_subject,
             "email_sender": email_sender,
             "email_date": email_date,
+            "file_name": file_name,
         },
     )
     row = cur.fetchone()
@@ -79,6 +94,7 @@ def search_receipts(
     amount_max: Decimal | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
+    source_name: str | None = None,
 ) -> list[Receipt]:
     """Search receipts with optional filters, combined with AND."""
     clauses: list[str] = []
@@ -107,6 +123,10 @@ def search_receipts(
     if date_to is not None:
         clauses.append("receipt_date <= %(date_to)s")
         params["date_to"] = date_to
+
+    if source_name is not None:
+        clauses.append("source_name = %(source_name)s")
+        params["source_name"] = source_name
 
     where = " AND ".join(clauses) if clauses else "TRUE"
     sql = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from receipt_index.config import ImapConfig
+from receipt_index.config import ImapSourceConfig
 from receipt_index.models import RawReceipt
 
 if TYPE_CHECKING:
@@ -23,9 +23,10 @@ def store_root(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def imap_config() -> ImapConfig:
+def imap_config() -> ImapSourceConfig:
     """Provide a test IMAP configuration."""
-    return ImapConfig(
+    return ImapSourceConfig(
+        name="test-imap",
         host="imap.example.com",
         username="test@example.com",
         password="secret",  # pragma: allowlist secret
@@ -39,8 +40,10 @@ def sample_raw_receipt() -> RawReceipt:
     """Provide a minimal RawReceipt for extraction and renderer tests."""
     return RawReceipt(
         source_id="<test-123@example.com>",
+        source_name="test-imap",
+        source_type="imap",
+        date=datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
         subject="Your Amazon.com order",
         sender="no-reply@amazon.com",
-        date=datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
         text_body="Order Total: $42.99\nItem: Python Cookbook",
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,9 +64,11 @@ def _run_migrations(conn: psycopg.Connection[dict[str, Any]]) -> None:
             description     TEXT,
             confidence      REAL NOT NULL,
             pdf_path        TEXT NOT NULL,
+            source_name     TEXT NOT NULL DEFAULT 'legacy-imap',
             email_subject   TEXT,
             email_sender    TEXT,
             email_date      TIMESTAMPTZ,
+            file_name       TEXT,
             created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from receipt_index.adapters.imap import ImapAdapter
-from receipt_index.config import ImapConfig
+from receipt_index.config import ImapSourceConfig
 from receipt_index.models import ReceiptMetadata
 from receipt_index.pipeline import run_ingest
 from receipt_index.repository import get_processed_source_ids, search_receipts
@@ -55,9 +55,10 @@ def _unique_user(prefix: str = "test") -> str:
     return f"{prefix}-{short_id}@localhost"
 
 
-def _greenmail_imap_config(user: str = "test@localhost") -> ImapConfig:
+def _greenmail_imap_config(user: str = "test@localhost") -> ImapSourceConfig:
     """IMAP config pointing at GreenMail."""
-    return ImapConfig(
+    return ImapSourceConfig(
+        name="greenmail-test",
         host="localhost",
         username=user,
         password="any",  # pragma: allowlist secret
@@ -94,6 +95,7 @@ class TestFullPipelineE2E:
             conn=pg_conn,
             adapter=adapter,
             store=store,
+            source_name="greenmail-test",
             agent=agent,
         )
 
@@ -135,13 +137,21 @@ class TestFullPipelineE2E:
 
         # First run
         r1 = run_ingest(
-            conn=pg_conn, adapter=ImapAdapter(config), store=store, agent=agent
+            conn=pg_conn,
+            adapter=ImapAdapter(config),
+            store=store,
+            source_name="greenmail-test",
+            agent=agent,
         )
         assert r1.processed == 1
 
         # Second run — same email should be skipped
         r2 = run_ingest(
-            conn=pg_conn, adapter=ImapAdapter(config), store=store, agent=agent
+            conn=pg_conn,
+            adapter=ImapAdapter(config),
+            store=store,
+            source_name="greenmail-test",
+            agent=agent,
         )
         assert r2.processed == 0
         assert r2.skipped == 0  # not dry_run, just no unprocessed messages
@@ -172,6 +182,7 @@ class TestFullPipelineE2E:
             conn=pg_conn,
             adapter=adapter,
             store=store,
+            source_name="greenmail-test",
             agent=_make_mock_agent(),
             dry_run=True,
         )
@@ -207,6 +218,7 @@ class TestFullPipelineE2E:
             conn=pg_conn,
             adapter=adapter,
             store=store,
+            source_name="greenmail-test",
             agent=agent,
         )
 
@@ -238,6 +250,7 @@ class TestFullPipelineE2E:
             conn=pg_conn,
             adapter=adapter,
             store=store,
+            source_name="greenmail-test",
             agent=agent,
             limit=2,
         )
@@ -274,6 +287,7 @@ class TestFullPipelineE2E:
             conn=pg_conn,
             adapter=adapter,
             store=store,
+            source_name="greenmail-test",
             agent=agent,
         )
 
@@ -324,7 +338,13 @@ class TestFullPipelineE2E:
         r1.output, r2.output = meta1, meta2
         agent.run_sync.side_effect = [r1, r2]
 
-        run_ingest(conn=pg_conn, adapter=adapter, store=store, agent=agent)
+        run_ingest(
+            conn=pg_conn,
+            adapter=adapter,
+            store=store,
+            source_name="greenmail-test",
+            agent=agent,
+        )
 
         # Search by vendor
         acme = search_receipts(pg_conn, vendor="ACME")

--- a/tests/integration/test_phase2.py
+++ b/tests/integration/test_phase2.py
@@ -1,0 +1,1413 @@
+"""Phase 2 integration tests: config-based sources, multi-source ingest, Drive adapter.
+
+Requires Docker services: Postgres (port 15432) and GreenMail (ports 3025/3143).
+Start with: docker compose up -d
+
+These tests exercise:
+- Config-based IMAP ingest (YAML config -> ImapAdapter -> pipeline)
+- Multi-source ingest (two named IMAP sources)
+- --source filtering (restrict ingest to one named source)
+- Idempotent re-ingest (no duplicates across multiple runs)
+- Search with source_name filter
+- GdriveAdapter with mocked Google API (through real Postgres)
+- DB migration 000005 (source_name, file_name columns added/removed cleanly)
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+import uuid
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from receipt_index.adapters.imap import ImapAdapter
+from receipt_index.models import ReceiptMetadata
+from receipt_index.pipeline import run_ingest
+from receipt_index.repository import get_processed_source_ids, search_receipts
+from receipt_index.store import LocalFileStore
+
+from .conftest import GREENMAIL_IMAP_PORT, seed_email
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import psycopg
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across test classes
+# ---------------------------------------------------------------------------
+
+
+def _unique_user(prefix: str = "p2") -> str:
+    """Generate a unique GreenMail mailbox address to avoid cross-run collisions."""
+    short_id = uuid.uuid4().hex[:8]
+    return f"{prefix}-{short_id}@localhost"
+
+
+def _make_mock_agent(
+    vendor: str = "TestVendor",
+    amount: Decimal = Decimal("42.99"),
+    receipt_date: date | None = None,
+    confidence: float = 0.90,
+) -> MagicMock:
+    """Return a mock extraction agent that always returns fixed metadata."""
+    meta = ReceiptMetadata(
+        vendor=vendor,
+        amount=amount,
+        date=receipt_date or date(2025, 6, 15),
+        confidence=confidence,
+    )
+    mock_result = MagicMock()
+    mock_result.output = meta
+    agent = MagicMock()
+    agent.run_sync.return_value = mock_result
+    return agent
+
+
+def _make_alternating_agent(
+    *receipts: tuple[str, Decimal, date],
+) -> MagicMock:
+    """Return a mock agent that cycles through (vendor, amount, date) tuples."""
+    results = []
+    for vendor, amount, rcpt_date in receipts:
+        meta = ReceiptMetadata(
+            vendor=vendor,
+            amount=amount,
+            date=rcpt_date,
+            confidence=0.90,
+        )
+        mock_result = MagicMock()
+        mock_result.output = meta
+        results.append(mock_result)
+    agent = MagicMock()
+    agent.run_sync.side_effect = results
+    return agent
+
+
+def _imap_config_for_user(user: str) -> Any:
+    """Return an ImapSourceConfig pointing at GreenMail for the given user."""
+    # Import here so tests fail clearly if Phase 2 config models are missing
+    from receipt_index.config import ImapSourceConfig
+
+    return ImapSourceConfig(
+        name="test-source",
+        type="imap",
+        host="localhost",
+        port=GREENMAIL_IMAP_PORT,
+        username=user,
+        password="any",  # pragma: allowlist secret
+        folder="INBOX",
+        use_ssl=False,
+    )
+
+
+def _make_app_config(sources: list[Any], db_url: str, store_path: str) -> Any:
+    """Construct an AppConfig with the given sources."""
+    from receipt_index.config import AppConfig, DatabaseConfig, LlmConfig, StoreConfig
+
+    return AppConfig(
+        sources=sources,
+        database=DatabaseConfig(url=db_url),
+        store=StoreConfig(path=store_path),
+        llm=LlmConfig(api_key="test-key"),  # pragma: allowlist secret
+    )
+
+
+# DB URL used by conftest for the test Postgres instance — unused at module level
+# but kept as a reference for any test that needs to open its own connection.
+_DB_URL = (
+    "postgresql://main:localpass@localhost:15432/"  # pragma: allowlist secret
+    "receipt_index_dev"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Config -> IMAP ingest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestConfigImapIngest:
+    """Config-based IMAP ingest: build ImapAdapter from ImapSourceConfig."""
+
+    def test_config_based_imap_ingest_happy_path(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Load IMAP source from config, run pipeline, verify DB and file store."""
+        user = _unique_user("cfg-imap")
+        seed_email(
+            to_addr=user,
+            from_addr="shop@example.com",
+            subject="Config-Based Receipt",
+            html_body="<p>Total: $55.00</p>",
+        )
+
+        source_cfg = _imap_config_for_user(user)
+        # Override source name to something meaningful
+        from receipt_index.config import ImapSourceConfig
+
+        source_cfg = ImapSourceConfig(
+            name="personal-email",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+
+        adapter = ImapAdapter(source_cfg)
+        store = LocalFileStore(tmp_path)
+        agent = _make_mock_agent(vendor="ShopCo", amount=Decimal("55.00"))
+
+        result = run_ingest(
+            conn=pg_conn,
+            adapter=adapter,
+            store=store,
+            agent=agent,
+            source_name="personal-email",
+        )
+
+        assert result.processed == 1
+        assert result.failed == 0
+
+        receipt = result.receipts[0]
+        assert receipt.source_name == "personal-email"
+        assert receipt.vendor == "ShopCo"
+        assert receipt.amount == Decimal("55.00")
+        assert store.exists(receipt.pdf_path)
+
+        rows = search_receipts(pg_conn, vendor="ShopCo")
+        assert len(rows) == 1
+        assert rows[0].source_name == "personal-email"
+
+    def test_config_imap_source_name_stored_in_db(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Verify source_name is persisted on the receipt row."""
+        user = _unique_user("srcname")
+        seed_email(
+            to_addr=user,
+            from_addr="billing@vendor.com",
+            subject="Source Name Test",
+            text_body="Total: $20.00",
+        )
+
+        from receipt_index.config import ImapSourceConfig
+
+        source_cfg = ImapSourceConfig(
+            name="work-receipts",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+        adapter = ImapAdapter(source_cfg)
+        store = LocalFileStore(tmp_path)
+        agent = _make_mock_agent(vendor="WorkVendor", amount=Decimal("20.00"))
+
+        run_ingest(
+            conn=pg_conn,
+            adapter=adapter,
+            store=store,
+            agent=agent,
+            source_name="work-receipts",
+        )
+
+        rows = pg_conn.execute(
+            "SELECT source_name FROM receipt.receipts WHERE vendor = %(v)s",
+            {"v": "WorkVendor"},
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["source_name"] == "work-receipts"
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-source config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMultiSourceIngest:
+    """Two named IMAP sources in a config; both are ingested and results aggregated."""
+
+    def test_two_imap_sources_both_ingested(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Ingest from two separate IMAP mailboxes, verify both rows in DB."""
+        user_a = _unique_user("multi-a")
+        user_b = _unique_user("multi-b")
+
+        seed_email(
+            to_addr=user_a,
+            from_addr="acme@example.com",
+            subject="ACME Receipt",
+            text_body="Total: $100.00",
+        )
+        seed_email(
+            to_addr=user_b,
+            from_addr="globex@example.com",
+            subject="Globex Receipt",
+            text_body="Total: $200.00",
+        )
+
+        from receipt_index.config import ImapSourceConfig
+
+        source_a = ImapSourceConfig(
+            name="source-a",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user_a,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+        source_b = ImapSourceConfig(
+            name="source-b",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user_b,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+
+        store = LocalFileStore(tmp_path)
+        agent_a = _make_mock_agent(vendor="ACME Corp", amount=Decimal("100.00"))
+        agent_b = _make_mock_agent(vendor="Globex Inc", amount=Decimal("200.00"))
+
+        result_a = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_a),
+            store=store,
+            agent=agent_a,
+            source_name="source-a",
+        )
+        result_b = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_b),
+            store=store,
+            agent=agent_b,
+            source_name="source-b",
+        )
+
+        assert result_a.processed == 1
+        assert result_b.processed == 1
+
+        # Both rows exist in DB, each tagged with correct source
+        all_rows = search_receipts(pg_conn)
+        assert len(all_rows) == 2
+
+        source_names = {r.source_name for r in all_rows}
+        assert source_names == {"source-a", "source-b"}
+
+    def test_two_sources_results_are_independently_tagged(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Each receipt row carries its own source_name, not the other source's."""
+        user_a = _unique_user("tag-a")
+        user_b = _unique_user("tag-b")
+
+        seed_email(to_addr=user_a, subject="Alpha Receipt", text_body="$10.00")
+        seed_email(to_addr=user_b, subject="Beta Receipt", text_body="$20.00")
+
+        from receipt_index.config import ImapSourceConfig
+
+        def _src(name: str, user: str) -> ImapSourceConfig:
+            return ImapSourceConfig(
+                name=name,
+                type="imap",
+                host="localhost",
+                port=GREENMAIL_IMAP_PORT,
+                username=user,
+                password="any",  # pragma: allowlist secret
+                folder="INBOX",
+                use_ssl=False,
+            )
+
+        store = LocalFileStore(tmp_path)
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("alpha", user_a)),
+            store=store,
+            agent=_make_mock_agent(vendor="AlphaVendor", amount=Decimal("10.00")),
+            source_name="alpha",
+        )
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("beta", user_b)),
+            store=store,
+            agent=_make_mock_agent(vendor="BetaVendor", amount=Decimal("20.00")),
+            source_name="beta",
+        )
+
+        alpha_rows = search_receipts(pg_conn, source_name="alpha")
+        beta_rows = search_receipts(pg_conn, source_name="beta")
+
+        assert len(alpha_rows) == 1
+        assert alpha_rows[0].vendor == "AlphaVendor"
+        assert alpha_rows[0].source_name == "alpha"
+
+        assert len(beta_rows) == 1
+        assert beta_rows[0].vendor == "BetaVendor"
+        assert beta_rows[0].source_name == "beta"
+
+
+# ---------------------------------------------------------------------------
+# 3. --source filtering: restrict ingest to one named source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestSourceFiltering:
+    """--source flag restricts ingest to the named source only."""
+
+    def test_source_filter_ingests_only_specified_source(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """When source_name is passed to run_ingest, only that source is processed."""
+        user_a = _unique_user("filter-a")
+        user_b = _unique_user("filter-b")
+
+        seed_email(to_addr=user_a, subject="Filter A Receipt", text_body="$30.00")
+        seed_email(to_addr=user_b, subject="Filter B Receipt", text_body="$40.00")
+
+        from receipt_index.config import ImapSourceConfig
+
+        source_a = ImapSourceConfig(
+            name="filter-source-a",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user_a,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+
+        store = LocalFileStore(tmp_path)
+        # Only ingest source-a, deliberately skip source-b
+        result = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_a),
+            store=store,
+            agent=_make_mock_agent(vendor="FilterVendorA", amount=Decimal("30.00")),
+            source_name="filter-source-a",
+        )
+
+        assert result.processed == 1
+
+        all_rows = search_receipts(pg_conn)
+        # Only source-a receipts in DB; source-b was never ingested
+        assert len(all_rows) == 1
+        assert all_rows[0].source_name == "filter-source-a"
+
+    def test_source_filter_idempotency_check_is_per_source(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Filtering processed IDs by source_name avoids cross-source collisions."""
+        user_a = _unique_user("pid-a")
+        user_b = _unique_user("pid-b")
+
+        seed_email(to_addr=user_a, subject="PID Source A", text_body="$50.00")
+        seed_email(to_addr=user_b, subject="PID Source B", text_body="$60.00")
+
+        from receipt_index.config import ImapSourceConfig
+
+        def _src(name: str, user: str) -> ImapSourceConfig:
+            return ImapSourceConfig(
+                name=name,
+                type="imap",
+                host="localhost",
+                port=GREENMAIL_IMAP_PORT,
+                username=user,
+                password="any",  # pragma: allowlist secret
+                folder="INBOX",
+                use_ssl=False,
+            )
+
+        store = LocalFileStore(tmp_path)
+
+        # Ingest source-a first
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("pid-a", user_a)),
+            store=store,
+            agent=_make_mock_agent(vendor="PidVendorA", amount=Decimal("50.00")),
+            source_name="pid-a",
+        )
+
+        # get_processed_source_ids filtered to "pid-b" returns empty set
+        # so source-b can ingest without interference from source-a's IDs
+        ids_b = get_processed_source_ids(pg_conn, source_name="pid-b")
+        assert len(ids_b) == 0
+
+        result_b = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("pid-b", user_b)),
+            store=store,
+            agent=_make_mock_agent(vendor="PidVendorB", amount=Decimal("60.00")),
+            source_name="pid-b",
+        )
+        assert result_b.processed == 1
+
+        all_rows = search_receipts(pg_conn)
+        assert len(all_rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotent re-ingest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestIdempotentReIngest:
+    """Running ingest twice on the same source must not produce duplicates."""
+
+    def test_imap_source_reingest_produces_no_duplicates(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Ingest once, then again — second run skips all already-processed IDs."""
+        user = _unique_user("idem")
+        seed_email(
+            to_addr=user,
+            from_addr="shop@example.com",
+            subject="Idempotent Receipt",
+            text_body="Total: $75.00",
+        )
+
+        from receipt_index.config import ImapSourceConfig
+
+        source_cfg = ImapSourceConfig(
+            name="idem-source",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+        store = LocalFileStore(tmp_path)
+        agent = _make_mock_agent(vendor="IdemVendor", amount=Decimal("75.00"))
+
+        # First run
+        r1 = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_cfg),
+            store=store,
+            agent=agent,
+            source_name="idem-source",
+        )
+        assert r1.processed == 1
+
+        # Second run — same messages, same source
+        r2 = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_cfg),
+            store=store,
+            agent=_make_mock_agent(vendor="IdemVendor", amount=Decimal("75.00")),
+            source_name="idem-source",
+        )
+        assert r2.processed == 0
+
+        # Exactly one row in DB
+        rows = search_receipts(pg_conn, vendor="IdemVendor")
+        assert len(rows) == 1
+
+    def test_reingest_after_new_email_only_processes_new_email(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """A new email arriving after first ingest is picked up on the next run."""
+        user = _unique_user("idem2")
+        seed_email(
+            to_addr=user,
+            subject="First Receipt",
+            text_body="$10.00",
+        )
+
+        from receipt_index.config import ImapSourceConfig
+
+        source_cfg = ImapSourceConfig(
+            name="idem2-source",
+            type="imap",
+            host="localhost",
+            port=GREENMAIL_IMAP_PORT,
+            username=user,
+            password="any",  # pragma: allowlist secret
+            folder="INBOX",
+            use_ssl=False,
+        )
+        store = LocalFileStore(tmp_path)
+
+        # First run: one email
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_cfg),
+            store=store,
+            agent=_make_mock_agent(vendor="FirstVendor", amount=Decimal("10.00")),
+            source_name="idem2-source",
+        )
+
+        # Seed a second email
+        seed_email(
+            to_addr=user,
+            subject="Second Receipt",
+            text_body="$20.00",
+        )
+
+        # Second run: should only process the new email
+        r2 = run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(source_cfg),
+            store=store,
+            agent=_make_mock_agent(vendor="SecondVendor", amount=Decimal("20.00")),
+            source_name="idem2-source",
+        )
+        assert r2.processed == 1
+
+        rows = search_receipts(pg_conn)
+        assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. Search with source filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestSearchWithSourceFilter:
+    """search_receipts with source_name filter returns only that source's receipts."""
+
+    def test_search_source_filter_returns_only_named_source(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Searching with source_name returns only receipts from that source."""
+        user_a = _unique_user("srch-a")
+        user_b = _unique_user("srch-b")
+
+        seed_email(to_addr=user_a, subject="Search Source A", text_body="$100.00")
+        seed_email(to_addr=user_b, subject="Search Source B", text_body="$200.00")
+
+        from receipt_index.config import ImapSourceConfig
+
+        def _src(name: str, user: str) -> ImapSourceConfig:
+            return ImapSourceConfig(
+                name=name,
+                type="imap",
+                host="localhost",
+                port=GREENMAIL_IMAP_PORT,
+                username=user,
+                password="any",  # pragma: allowlist secret
+                folder="INBOX",
+                use_ssl=False,
+            )
+
+        store = LocalFileStore(tmp_path)
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("search-a", user_a)),
+            store=store,
+            agent=_make_mock_agent(vendor="SearchVendorA", amount=Decimal("100.00")),
+            source_name="search-a",
+        )
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("search-b", user_b)),
+            store=store,
+            agent=_make_mock_agent(vendor="SearchVendorB", amount=Decimal("200.00")),
+            source_name="search-b",
+        )
+
+        results_a = search_receipts(pg_conn, source_name="search-a")
+        results_b = search_receipts(pg_conn, source_name="search-b")
+        results_all = search_receipts(pg_conn)
+
+        assert len(results_a) == 1
+        assert results_a[0].vendor == "SearchVendorA"
+
+        assert len(results_b) == 1
+        assert results_b[0].vendor == "SearchVendorB"
+
+        assert len(results_all) == 2
+
+    def test_search_source_filter_combined_with_vendor_filter(
+        self,
+        greenmail_available: bool,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """source_name filter composes correctly with other search filters."""
+        user_a = _unique_user("combo-a")
+        user_b = _unique_user("combo-b")
+
+        # Both sources have a receipt from "ACME"
+        seed_email(to_addr=user_a, subject="ACME A", text_body="$50.00")
+        seed_email(to_addr=user_b, subject="ACME B", text_body="$50.00")
+
+        from receipt_index.config import ImapSourceConfig
+
+        def _src(name: str, user: str) -> ImapSourceConfig:
+            return ImapSourceConfig(
+                name=name,
+                type="imap",
+                host="localhost",
+                port=GREENMAIL_IMAP_PORT,
+                username=user,
+                password="any",  # pragma: allowlist secret
+                folder="INBOX",
+                use_ssl=False,
+            )
+
+        store = LocalFileStore(tmp_path)
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("combo-a", user_a)),
+            store=store,
+            agent=_make_mock_agent(vendor="ACME Corp", amount=Decimal("50.00")),
+            source_name="combo-a",
+        )
+        run_ingest(
+            conn=pg_conn,
+            adapter=ImapAdapter(_src("combo-b", user_b)),
+            store=store,
+            agent=_make_mock_agent(vendor="ACME Corp", amount=Decimal("50.00")),
+            source_name="combo-b",
+        )
+
+        # Search vendor=ACME in combo-a only
+        results = search_receipts(pg_conn, vendor="ACME", source_name="combo-a")
+        assert len(results) == 1
+        assert results[0].source_name == "combo-a"
+
+    def test_search_nonexistent_source_returns_empty(
+        self,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+    ) -> None:
+        """Searching with a source_name that has no receipts returns an empty list."""
+        results = search_receipts(pg_conn, source_name="nonexistent-source")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Mock Drive adapter test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGdriveAdapterMocked:
+    """GdriveAdapter through real Postgres DB with mocked Google API calls."""
+
+    def _make_gdrive_source_config(self) -> Any:
+        """Return a GdriveSourceConfig with dummy credentials."""
+        from receipt_index.config import GdriveSourceConfig
+
+        # Minimal valid OAuth JSON stubs (structure matters, not values)
+        credentials_json = json.dumps(
+            {
+                "installed": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-secret",  # pragma: allowlist secret
+                    "redirect_uris": ["http://localhost"],
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                }
+            }
+        )
+        token_json = json.dumps(
+            {
+                "token": "ya29.test-access-token",
+                "refresh_token": "1//test-refresh-token",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "client_id": "test-client-id.apps.googleusercontent.com",
+                "client_secret": "test-secret",  # pragma: allowlist secret
+                "scopes": ["https://www.googleapis.com/auth/drive.readonly"],
+                "expiry": "2099-01-01T00:00:00Z",
+            }
+        )
+        return GdriveSourceConfig(
+            name="scanned-receipts",
+            type="gdrive",
+            folder_id="1aBcDeFgHiJkLmNoPqRsTuVwXyZ",
+            credentials_json=credentials_json,
+            token_json=token_json,
+        )
+
+    def _make_fake_pdf(self) -> bytes:
+        """Return a minimal valid PDF bytes for testing."""
+        # A real single-page PDF generated via weasyprint or a hard-coded minimal stub.
+        # We use a pre-baked minimal PDF structure that passes basic validation.
+        return (
+            b"%PDF-1.4\n"
+            b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R"
+            b" /MediaBox [0 0 612 792] >>\nendobj\n"
+            b"xref\n0 4\n0000000000 65535 f \n"
+            b"0000000009 00000 n \n"
+            b"0000000058 00000 n \n"
+            b"0000000115 00000 n \n"
+            b"trailer\n<< /Size 4 /Root 1 0 R >>\n"
+            b"startxref\n190\n%%EOF"
+        )
+
+    def _make_fake_jpeg(self) -> bytes:
+        """Return a minimal valid JPEG header for testing."""
+        # Minimal 1x1 white JPEG
+        return (
+            b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+            b"\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t"
+            b"\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a"
+            b"\x1f\x1e\x1d\x1a\x1c\x1c $.' \",#\x1c\x1c(7),01444\x1f'9=82<.342\x1e"
+            b"\xff\xd9"
+        )
+
+    @patch("receipt_index.adapters.gdrive.GdriveAdapter._build_service")
+    def test_gdrive_pdf_ingested_via_real_postgres(
+        self,
+        mock_build_service: MagicMock,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """GdriveAdapter with mocked Drive API ingests a PDF through real Postgres."""
+        from receipt_index.adapters.gdrive import GdriveAdapter
+
+        fake_pdf = self._make_fake_pdf()
+        file_id = "drive-file-id-pdf-001"
+        modified_time = "2025-06-15T10:30:00Z"
+
+        # Mock the Drive service: list files, download content
+        mock_service = MagicMock()
+        mock_build_service.return_value = mock_service
+
+        # _list_files response
+        mock_service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {
+                    "id": file_id,
+                    "name": "acme-receipt-june.pdf",
+                    "mimeType": "application/pdf",
+                    "modifiedTime": modified_time,
+                }
+            ]
+        }
+
+        # _download_file response: returns (content_bytes, mime_type)
+        mock_media = MagicMock()
+        mock_media.status = (None, b"100")
+        # Simulate MediaIoBaseDownload writing bytes to the buffer
+        mock_service.files.return_value.get_media.return_value = MagicMock()
+
+        config = self._make_gdrive_source_config()
+        adapter = GdriveAdapter(config)
+
+        # Patch _download_file to avoid actual HTTP calls
+        with patch.object(
+            adapter,
+            "_download_file",
+            return_value=(fake_pdf, "application/pdf"),
+        ):
+            store = LocalFileStore(tmp_path)
+            agent = _make_mock_agent(
+                vendor="ACME Corp",
+                amount=Decimal("88.50"),
+                receipt_date=date(2025, 6, 15),
+            )
+
+            result = run_ingest(
+                conn=pg_conn,
+                adapter=adapter,
+                store=store,
+                agent=agent,
+                source_name="scanned-receipts",
+            )
+
+        assert result.processed == 1
+        assert result.failed == 0
+
+        receipt = result.receipts[0]
+        assert receipt.source_name == "scanned-receipts"
+        assert receipt.source_type == "gdrive"
+        assert receipt.vendor == "ACME Corp"
+        assert receipt.file_name == "acme-receipt-june.pdf"
+        assert store.exists(receipt.pdf_path)
+
+        rows = search_receipts(pg_conn, source_name="scanned-receipts")
+        assert len(rows) == 1
+        assert rows[0].file_name == "acme-receipt-june.pdf"
+
+    @patch("receipt_index.adapters.gdrive.GdriveAdapter._build_service")
+    def test_gdrive_skips_already_processed_file_ids(
+        self,
+        mock_build_service: MagicMock,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Drive adapter skips file IDs already in the processed set."""
+        from receipt_index.adapters.gdrive import GdriveAdapter
+
+        file_id = "drive-file-id-dupe-001"
+        modified_time = "2025-06-20T08:00:00Z"
+        fake_pdf = self._make_fake_pdf()
+
+        mock_service = MagicMock()
+        mock_build_service.return_value = mock_service
+        mock_service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {
+                    "id": file_id,
+                    "name": "dupe-receipt.pdf",
+                    "mimeType": "application/pdf",
+                    "modifiedTime": modified_time,
+                }
+            ]
+        }
+
+        config = self._make_gdrive_source_config()
+        adapter = GdriveAdapter(config)
+        store = LocalFileStore(tmp_path)
+
+        with patch.object(
+            adapter,
+            "_download_file",
+            return_value=(fake_pdf, "application/pdf"),
+        ):
+            agent = _make_mock_agent(vendor="DupeVendor", amount=Decimal("15.00"))
+
+            # First ingest
+            r1 = run_ingest(
+                conn=pg_conn,
+                adapter=adapter,
+                store=store,
+                agent=agent,
+                source_name="scanned-receipts",
+            )
+            assert r1.processed == 1
+
+        # Re-configure mock for second call (same file listing)
+        mock_service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {
+                    "id": file_id,
+                    "name": "dupe-receipt.pdf",
+                    "mimeType": "application/pdf",
+                    "modifiedTime": modified_time,
+                }
+            ]
+        }
+
+        adapter2 = GdriveAdapter(config)
+        with patch.object(
+            adapter2,
+            "_download_file",
+            return_value=(fake_pdf, "application/pdf"),
+        ):
+            r2 = run_ingest(
+                conn=pg_conn,
+                adapter=adapter2,
+                store=store,
+                agent=_make_mock_agent(vendor="DupeVendor", amount=Decimal("15.00")),
+                source_name="scanned-receipts",
+            )
+
+        assert r2.processed == 0
+        rows = search_receipts(pg_conn, vendor="DupeVendor")
+        assert len(rows) == 1
+
+    @patch("receipt_index.adapters.gdrive.GdriveAdapter._build_service")
+    def test_gdrive_unsupported_mime_type_is_skipped(
+        self,
+        mock_build_service: MagicMock,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """Files with unsupported MIME types are skipped (not ingested, not errored)."""
+        from receipt_index.adapters.gdrive import GdriveAdapter
+
+        mock_service = MagicMock()
+        mock_build_service.return_value = mock_service
+        mock_service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {
+                    "id": "drive-file-id-zip",
+                    "name": "data.zip",
+                    "mimeType": "application/zip",
+                    "modifiedTime": "2025-06-01T00:00:00Z",
+                }
+            ]
+        }
+
+        config = self._make_gdrive_source_config()
+        adapter = GdriveAdapter(config)
+        store = LocalFileStore(tmp_path)
+
+        result = run_ingest(
+            conn=pg_conn,
+            adapter=adapter,
+            store=store,
+            agent=_make_mock_agent(),
+            source_name="scanned-receipts",
+        )
+
+        # Nothing processed or failed — unsupported files are silently skipped
+        assert result.processed == 0
+        assert result.failed == 0
+
+    @patch("receipt_index.adapters.gdrive.GdriveAdapter._build_service")
+    def test_gdrive_empty_folder_produces_no_results(
+        self,
+        mock_build_service: MagicMock,
+        pg_conn: psycopg.Connection[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        """An empty Drive folder yields no ingest results."""
+        from receipt_index.adapters.gdrive import GdriveAdapter
+
+        mock_service = MagicMock()
+        mock_build_service.return_value = mock_service
+        mock_service.files.return_value.list.return_value.execute.return_value = {
+            "files": []
+        }
+
+        config = self._make_gdrive_source_config()
+        adapter = GdriveAdapter(config)
+        store = LocalFileStore(tmp_path)
+
+        result = run_ingest(
+            conn=pg_conn,
+            adapter=adapter,
+            store=store,
+            agent=_make_mock_agent(),
+            source_name="scanned-receipts",
+        )
+
+        assert result.processed == 0
+        assert result.failed == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. DB migration 000005: source_name and file_name columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMigration000005:
+    """Verify migration 000005 (source_name, file_name) applies and rolls back cleanly.
+
+    This class manages its own schema state — it tears down and re-applies
+    the full schema to test migration transitions. It does NOT use the shared
+    pg_conn fixture to avoid corrupting other tests' state.
+    """
+
+    # DSN matches conftest._DB_DSN
+    _DSN = (
+        "postgresql://main:localpass@localhost:15432/"  # pragma: allowlist secret
+        "receipt_index_dev"
+    )
+
+    def _fresh_conn(self) -> Any:
+        """Open a new connection (caller is responsible for closing)."""
+        import psycopg as pg
+
+        try:
+            conn = pg.connect(self._DSN, row_factory=pg.rows.dict_row)
+        except Exception:
+            pytest.skip("Postgres not available for migration test")
+        return conn
+
+    def _schema_exists_pre_migration(self, conn: Any) -> bool:
+        """Return True if source_name column is absent (pre-migration state)."""
+        row = conn.execute(
+            """\
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'receipt'
+              AND table_name = 'receipts'
+              AND column_name = 'source_name'
+            """
+        ).fetchone()
+        return row is None
+
+    def _apply_migration_up(self, conn: Any) -> None:
+        """Apply migration 000005 up: add source_name and file_name columns."""
+        conn.execute(
+            """\
+            ALTER TABLE receipt.receipts
+                ADD COLUMN IF NOT EXISTS source_name TEXT,
+                ADD COLUMN IF NOT EXISTS file_name TEXT
+            """
+        )
+        # Backfill existing rows
+        conn.execute(
+            "UPDATE receipt.receipts SET source_name = 'legacy-imap' "
+            "WHERE source_name IS NULL"
+        )
+        conn.execute(
+            "ALTER TABLE receipt.receipts ALTER COLUMN source_name SET NOT NULL"
+        )
+        conn.commit()
+
+    def _apply_migration_down(self, conn: Any) -> None:
+        """Apply migration 000005 down: drop source_name and file_name columns."""
+        conn.execute(
+            """\
+            ALTER TABLE receipt.receipts
+                DROP COLUMN IF EXISTS source_name,
+                DROP COLUMN IF EXISTS file_name
+            """
+        )
+        conn.commit()
+
+    def _columns_present(self, conn: Any, *column_names: str) -> dict[str, bool]:
+        """Return a dict mapping column_name -> True if present in receipt.receipts."""
+        rows = conn.execute(
+            """\
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'receipt' AND table_name = 'receipts'
+            """
+        ).fetchall()
+        existing = {r["column_name"] for r in rows}
+        return {col: col in existing for col in column_names}
+
+    def test_migration_up_adds_source_name_and_file_name_columns(self) -> None:
+        """Migration up: source_name NOT NULL (backfilled), file_name nullable."""
+        conn = self._fresh_conn()
+        try:
+            # Ensure we start from a state without the new columns
+            self._apply_migration_down(conn)
+
+            # Confirm pre-migration state
+            present_before = self._columns_present(conn, "source_name", "file_name")
+            assert not present_before["source_name"]
+            assert not present_before["file_name"]
+
+            # Apply migration up
+            self._apply_migration_up(conn)
+
+            present_after = self._columns_present(conn, "source_name", "file_name")
+            assert present_after["source_name"]
+            assert present_after["file_name"]
+
+            # source_name should be NOT NULL
+            row = conn.execute(
+                """\
+                SELECT is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'receipt'
+                  AND table_name = 'receipts'
+                  AND column_name = 'source_name'
+                """
+            ).fetchone()
+            assert row is not None
+            assert row["is_nullable"] == "NO"
+
+            # file_name should be nullable
+            row = conn.execute(
+                """\
+                SELECT is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'receipt'
+                  AND table_name = 'receipts'
+                  AND column_name = 'file_name'
+                """
+            ).fetchone()
+            assert row is not None
+            assert row["is_nullable"] == "YES"
+        finally:
+            conn.close()
+
+    def test_migration_down_removes_source_name_and_file_name_columns(self) -> None:
+        """Migration down drops both columns cleanly."""
+        conn = self._fresh_conn()
+        try:
+            # Start with columns present
+            self._apply_migration_up(conn)
+
+            present_before = self._columns_present(conn, "source_name", "file_name")
+            assert present_before["source_name"]
+            assert present_before["file_name"]
+
+            # Roll back
+            self._apply_migration_down(conn)
+
+            present_after = self._columns_present(conn, "source_name", "file_name")
+            assert not present_after["source_name"]
+            assert not present_after["file_name"]
+        finally:
+            conn.close()
+
+    def test_migration_up_backfills_existing_rows_with_legacy_imap(self) -> None:
+        """Existing rows with NULL source_name are backfilled to 'legacy-imap'."""
+        conn = self._fresh_conn()
+        try:
+            # Drop columns so we can insert a row without source_name
+            self._apply_migration_down(conn)
+
+            # Insert a receipt row (pre-migration schema has no source_name)
+            conn.execute(
+                """\
+                INSERT INTO receipt.receipts (
+                    source_id, source_type, vendor, amount, currency,
+                    receipt_date, confidence, pdf_path
+                ) VALUES (
+                    'legacy-test-id', 'imap', 'LegacyVendor', 10.00, 'USD',
+                    '2024-01-01', 0.9, 'legacy/path.pdf'
+                )
+                """
+            )
+            conn.commit()
+
+            # Apply migration up — should backfill the row
+            self._apply_migration_up(conn)
+
+            row = conn.execute(
+                "SELECT source_name FROM receipt.receipts "
+                "WHERE source_id = 'legacy-test-id'"
+            ).fetchone()
+            assert row is not None
+            assert row["source_name"] == "legacy-imap"
+        finally:
+            # Clean up
+            try:
+                conn.execute(
+                    "DELETE FROM receipt.receipts WHERE source_id = 'legacy-test-id'"
+                )
+                conn.commit()
+            except Exception:
+                pass
+            conn.close()
+
+    def test_migration_up_down_up_is_idempotent(self) -> None:
+        """Running up -> down -> up produces the same final schema."""
+        conn = self._fresh_conn()
+        try:
+            self._apply_migration_up(conn)
+            self._apply_migration_down(conn)
+            self._apply_migration_up(conn)
+
+            present = self._columns_present(conn, "source_name", "file_name")
+            assert present["source_name"]
+            assert present["file_name"]
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 8. load_config() integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLoadConfigIntegration:
+    """load_config() correctly parses YAML and env var interpolation end-to-end."""
+
+    def test_load_config_single_imap_source(self, tmp_path: Path) -> None:
+        """A minimal IMAP config file is parsed into AppConfig with correct values."""
+        from receipt_index.config import load_config
+
+        config_file = tmp_path / "receipt-index.yaml"
+        config_file.write_text(
+            textwrap.dedent(
+                """\
+                sources:
+                  - name: personal-email
+                    type: imap
+                    host: mail.example.com
+                    port: 993
+                    username: user@example.com
+                    password: secret123
+                    folder: INBOX.Receipts
+                    use_ssl: true
+
+                database:
+                  url: postgresql://user:pass@localhost/db  # pragma: allowlist secret
+
+                store:
+                  path: /tmp/receipts
+
+                llm:
+                  api_key: sk-test-key
+                """
+            )
+        )
+
+        config = load_config(config_file)
+
+        assert len(config.sources) == 1
+        source = config.sources[0]
+        assert source.name == "personal-email"
+        assert source.type == "imap"
+        assert source.host == "mail.example.com"  # type: ignore[union-attr]
+        assert source.folder == "INBOX.Receipts"  # type: ignore[union-attr]
+        assert (
+            config.database.url == "postgresql://user:pass@localhost/db"
+        )  # pragma: allowlist secret
+
+    def test_load_config_env_var_interpolation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """${VAR} references in YAML are resolved from the environment."""
+        from receipt_index.config import load_config
+
+        monkeypatch.setenv(  # pragma: allowlist secret
+            "TEST_IMAP_PASSWORD", "supersecret"
+        )
+        monkeypatch.setenv("TEST_DB_URL", "postgresql://test/testdb")
+
+        config_file = tmp_path / "receipt-index.yaml"
+        config_file.write_text(
+            textwrap.dedent(
+                """\
+                sources:
+                  - name: test-email
+                    type: imap
+                    host: localhost
+                    port: 143
+                    username: user@test.com
+                    password: ${TEST_IMAP_PASSWORD}
+                    use_ssl: false
+
+                database:
+                  url: ${TEST_DB_URL}
+
+                llm:
+                  api_key: test-key
+                """
+            )
+        )
+
+        config = load_config(config_file)
+
+        assert config.sources[0].password == "supersecret"  # type: ignore[union-attr]
+        assert config.database.url == "postgresql://test/testdb"
+
+    def test_load_config_missing_env_var_raises_clear_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A config with unset ${VAR} raises ValueError naming all missing variables."""
+        from receipt_index.config import load_config
+
+        # Ensure the var is NOT set
+        monkeypatch.delenv("MISSING_VAR_ONE", raising=False)
+        monkeypatch.delenv("MISSING_VAR_TWO", raising=False)
+
+        config_file = tmp_path / "receipt-index.yaml"
+        config_file.write_text(
+            textwrap.dedent(
+                """\
+                sources:
+                  - name: test-email
+                    type: imap
+                    host: localhost
+                    port: 143
+                    username: user@test.com
+                    password: ${MISSING_VAR_ONE}
+                    use_ssl: false
+
+                database:
+                  url: ${MISSING_VAR_TWO}
+
+                llm:
+                  api_key: test-key
+                """
+            )
+        )
+
+        with pytest.raises(ValueError, match="MISSING_VAR"):
+            load_config(config_file)
+
+    def test_load_config_two_sources(self, tmp_path: Path) -> None:
+        """A config with two sources (IMAP and GDrive) is parsed correctly."""
+        from receipt_index.config import (
+            GdriveSourceConfig,
+            ImapSourceConfig,
+            load_config,
+        )
+
+        config_file = tmp_path / "receipt-index.yaml"
+        config_file.write_text(
+            textwrap.dedent(
+                """\
+                sources:
+                  - name: personal-email
+                    type: imap
+                    host: mail.example.com
+                    username: user@example.com
+                    password: imap-pass
+                    folder: INBOX.Receipts
+
+                  - name: scanned-receipts
+                    type: gdrive
+                    folder_id: "1aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+                    credentials_json: '{"installed": {}}'
+                    token_json: '{"token": "tok"}'
+
+                database:
+                  url: postgresql://localhost/db
+
+                llm:
+                  api_key: test-key
+                """
+            )
+        )
+
+        config = load_config(config_file)
+
+        assert len(config.sources) == 2
+        imap_src = config.sources[0]
+        gdrive_src = config.sources[1]
+
+        assert isinstance(imap_src, ImapSourceConfig)
+        assert imap_src.name == "personal-email"
+
+        assert isinstance(gdrive_src, GdriveSourceConfig)
+        assert gdrive_src.name == "scanned-receipts"
+        assert gdrive_src.folder_id == "1aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+
+    def test_load_config_missing_file_raises_clear_error(self, tmp_path: Path) -> None:
+        """A nonexistent config path raises FileNotFoundError or ValueError."""
+        from receipt_index.config import load_config
+
+        missing = tmp_path / "does-not-exist.yaml"
+        with pytest.raises((FileNotFoundError, ValueError)):
+            load_config(missing)

--- a/tests/integration/test_phase2.py
+++ b/tests/integration/test_phase2.py
@@ -741,18 +741,6 @@ class TestGdriveAdapterMocked:
         """Return a GdriveSourceConfig with dummy credentials."""
         from receipt_index.config import GdriveSourceConfig
 
-        # Minimal valid OAuth JSON stubs (structure matters, not values)
-        credentials_json = json.dumps(
-            {
-                "installed": {
-                    "client_id": "test-client-id.apps.googleusercontent.com",
-                    "client_secret": "test-secret",  # pragma: allowlist secret
-                    "redirect_uris": ["http://localhost"],
-                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri": "https://oauth2.googleapis.com/token",
-                }
-            }
-        )
         token_json = json.dumps(
             {
                 "token": "ya29.test-access-token",
@@ -768,7 +756,6 @@ class TestGdriveAdapterMocked:
             name="scanned-receipts",
             type="gdrive",
             folder_id="1aBcDeFgHiJkLmNoPqRsTuVwXyZ",
-            credentials_json=credentials_json,
             token_json=token_json,
         )
 
@@ -1379,7 +1366,6 @@ class TestLoadConfigIntegration:
                   - name: scanned-receipts
                     type: gdrive
                     folder_id: "1aBcDeFgHiJkLmNoPqRsTuVwXyZ"
-                    credentials_json: '{"installed": {}}'
                     token_json: '{"token": "tok"}'
 
                 database:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,214 @@
+"""Tests for receipt_index.auth."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from receipt_index.auth import AuthError, run_gdrive_auth
+from receipt_index.cli import cli
+
+
+def _make_mock_credentials() -> MagicMock:
+    """Create a mock Google OAuth2 credentials object."""
+    creds = MagicMock()
+    creds.token = "ya29.test-access-token"
+    creds.refresh_token = "1//test-refresh-token"
+    creds.token_uri = "https://oauth2.googleapis.com/token"
+    creds.client_id = "123456.apps.googleusercontent.com"
+    creds.client_secret = "test-client-secret"  # pragma: allowlist secret
+    creds.scopes = ["https://www.googleapis.com/auth/drive.readonly"]
+    return creds
+
+
+class TestRunGdriveAuth:
+    """Tests for run_gdrive_auth()."""
+
+    def test_successful_auth_returns_token_json(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "client_secret.json"
+        creds_file.write_text('{"installed": {"client_id": "test"}}')
+
+        mock_creds = _make_mock_credentials()
+
+        with patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_from_file:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.return_value = mock_creds
+            mock_from_file.return_value = mock_flow
+
+            result = run_gdrive_auth(str(creds_file))
+
+        token_data = json.loads(result)
+        assert token_data["token"] == "ya29.test-access-token"
+        assert token_data["refresh_token"] == "1//test-refresh-token"
+        assert token_data["token_uri"] == "https://oauth2.googleapis.com/token"
+        assert token_data["client_id"] == "123456.apps.googleusercontent.com"
+        assert (
+            token_data["client_secret"] == "test-client-secret"
+        )  # pragma: allowlist secret
+        assert token_data["scopes"] == [
+            "https://www.googleapis.com/auth/drive.readonly"
+        ]
+
+    def test_uses_correct_scopes(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "client_secret.json"
+        creds_file.write_text('{"installed": {"client_id": "test"}}')
+
+        mock_creds = _make_mock_credentials()
+
+        with patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_from_file:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.return_value = mock_creds
+            mock_from_file.return_value = mock_flow
+
+            run_gdrive_auth(str(creds_file))
+
+        mock_from_file.assert_called_once_with(
+            str(creds_file),
+            scopes=["https://www.googleapis.com/auth/drive.readonly"],
+        )
+
+    def test_file_not_found_raises_auth_error(self) -> None:
+        with pytest.raises(AuthError, match="not found"):
+            run_gdrive_auth("/nonexistent/path/client_secret.json")
+
+    def test_invalid_credentials_file_raises_auth_error(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "bad_creds.json"
+        creds_file.write_text("not valid json {{{")
+
+        with (
+            patch(
+                "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file",
+                side_effect=ValueError("Invalid client secrets"),
+            ),
+            pytest.raises(AuthError, match="Invalid client credentials"),
+        ):
+            run_gdrive_auth(str(creds_file))
+
+    def test_auth_flow_cancelled_raises_auth_error(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "client_secret.json"
+        creds_file.write_text('{"installed": {"client_id": "test"}}')
+
+        with patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_from_file:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.side_effect = RuntimeError(
+                "Authorization cancelled"
+            )
+            mock_from_file.return_value = mock_flow
+
+            with pytest.raises(AuthError, match="Authorization flow failed"):
+                run_gdrive_auth(str(creds_file))
+
+    def test_none_scopes_defaults_to_drive_readonly(self, tmp_path: Path) -> None:
+        """When credentials.scopes is None, use the default scopes."""
+        creds_file = tmp_path / "client_secret.json"
+        creds_file.write_text('{"installed": {"client_id": "test"}}')
+
+        mock_creds = _make_mock_credentials()
+        mock_creds.scopes = None
+
+        with patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_from_file:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.return_value = mock_creds
+            mock_from_file.return_value = mock_flow
+
+            result = run_gdrive_auth(str(creds_file))
+
+        token_data = json.loads(result)
+        assert token_data["scopes"] == [
+            "https://www.googleapis.com/auth/drive.readonly"
+        ]
+
+
+class TestAuthGdriveCli:
+    """Tests for the 'auth gdrive' CLI command."""
+
+    def test_successful_auth_outputs_token(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "client_secret.json"
+        creds_file.write_text('{"installed": {"client_id": "test"}}')
+
+        mock_creds = _make_mock_credentials()
+        token_json = json.dumps(
+            {
+                "token": mock_creds.token,
+                "refresh_token": mock_creds.refresh_token,
+                "token_uri": mock_creds.token_uri,
+                "client_id": mock_creds.client_id,
+                "client_secret": mock_creds.client_secret,
+                "scopes": list(mock_creds.scopes),
+            }
+        )
+
+        runner = CliRunner()
+        with patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_from_file:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.return_value = mock_creds
+            mock_from_file.return_value = mock_flow
+
+            result = runner.invoke(
+                cli,
+                ["auth", "gdrive", "--client-credentials", str(creds_file)],
+            )
+
+        assert result.exit_code == 0
+        assert "Authorization successful" in result.output
+        assert "GDRIVE_TOKEN_JSON" in result.output
+        assert token_json in result.output
+
+    def test_auth_error_shows_message_and_exits_1(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "gdrive",
+                "--client-credentials",
+                str(tmp_path / "nonexistent.json"),
+            ],
+        )
+
+        # click.Path(exists=True) catches the missing file before our code
+        assert result.exit_code != 0
+
+    def test_missing_client_credentials_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["auth", "gdrive"])
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+    def test_auth_flow_failure_exits_1(self, tmp_path: Path) -> None:
+        creds_file = tmp_path / "client_secret.json"
+        creds_file.write_text('{"installed": {"client_id": "test"}}')
+
+        runner = CliRunner()
+        with patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_from_file:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.side_effect = RuntimeError("Network error")
+            mock_from_file.return_value = mock_flow
+
+            result = runner.invoke(
+                cli,
+                ["auth", "gdrive", "--client-credentials", str(creds_file)],
+            )
+
+        assert result.exit_code == 1
+        assert "Error:" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -279,7 +279,6 @@ class TestIngestCommand:
             name="scanned-receipts",
             type="gdrive",
             folder_id="abc123",
-            credentials_json="{}",
             token_json="{}",
         )
         config_with_gdrive = config.model_copy(update={"sources": [gdrive_source]})

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import json
+import textwrap
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from pathlib import Path  # noqa: TC003
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+import pytest
 from click.testing import CliRunner
 
 from receipt_index.cli import cli
+from receipt_index.config import AppConfig, ImapSourceConfig
 from receipt_index.models import IngestLogEntry, Receipt
 from receipt_index.pipeline import IngestResult
 
@@ -19,6 +23,7 @@ _RECEIPT_ROW: dict[str, Any] = {
     "id": UUID("019572a0-0000-7000-8000-000000000001"),
     "source_id": "<msg-1@example.com>",
     "source_type": "imap",
+    "source_name": "personal-email",
     "vendor": "Amazon",
     "amount": Decimal("42.99"),
     "currency": "USD",
@@ -29,6 +34,7 @@ _RECEIPT_ROW: dict[str, Any] = {
     "email_subject": "Your Amazon.com order",
     "email_sender": "no-reply@amazon.com",
     "email_date": datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
+    "file_name": None,
     "created_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
     "updated_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
 }
@@ -52,6 +58,60 @@ _FAILURE_ROW: dict[str, Any] = {
 
 _SAMPLE_FAILURE = IngestLogEntry.model_validate(_FAILURE_ROW)
 
+_MINIMAL_CONFIG_YAML = textwrap.dedent("""\
+    sources:
+      - name: test-email
+        type: imap
+        host: mail.example.com
+        username: user@example.com
+        password: secret
+        folder: INBOX
+
+    database:
+      url: postgresql://localhost/test
+
+    store:
+      path: ./data/receipts
+
+    llm:
+      model: claude-haiku-4-5-20251001
+      api_key: test-key
+
+    logging:
+      level: INFO
+""")
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Path:
+    """Write a minimal config file and return its path."""
+    config_path = tmp_path / "receipt-index.yaml"
+    config_path.write_text(_MINIMAL_CONFIG_YAML)
+    return config_path
+
+
+def _make_config() -> AppConfig:
+    """Build an AppConfig for testing without touching the filesystem."""
+    return AppConfig(
+        sources=[
+            ImapSourceConfig(
+                name="test-email",
+                type="imap",
+                host="mail.example.com",
+                username="user@example.com",
+                password="secret",  # pragma: allowlist secret
+                folder="INBOX",
+            ),
+        ],
+        database={"url": "postgresql://localhost/test"},  # type: ignore[arg-type]
+        store={"path": "./data/receipts"},  # type: ignore[arg-type]
+        llm={  # type: ignore[arg-type]
+            "model": "claude-haiku-4-5-20251001",
+            "api_key": "test-key",  # pragma: allowlist secret
+        },
+        logging={"level": "INFO"},  # type: ignore[arg-type]
+    )
+
 
 class TestIngestCommand:
     """Tests for the ingest CLI command."""
@@ -59,87 +119,185 @@ class TestIngestCommand:
     @patch("receipt_index.pipeline.run_ingest")
     @patch("receipt_index.db.get_connection")
     @patch("receipt_index.store.LocalFileStore")
-    @patch("receipt_index.config.get_store_path")
+    @patch("receipt_index.extraction.create_extraction_agent")
     @patch("receipt_index.adapters.imap.ImapAdapter")
-    @patch("receipt_index.config.get_imap_config")
+    @patch("receipt_index.cli.load_config")
     def test_ingest_success(
         self,
-        mock_imap_config: MagicMock,
+        mock_load_config: MagicMock,
         mock_adapter_cls: MagicMock,
-        mock_store_path: MagicMock,
+        mock_create_agent: MagicMock,
         mock_store_cls: MagicMock,
         mock_get_conn: MagicMock,
         mock_run: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         mock_run.return_value = IngestResult(processed=3, skipped=0, failed=0)
         runner = CliRunner()
-        result = runner.invoke(cli, ["ingest"])
-        assert result.exit_code == 0
+        result = runner.invoke(cli, ["--config", str(config_file), "ingest"])
+        assert result.exit_code == 0, result.output
         assert "Processed: 3" in result.output
 
     @patch("receipt_index.pipeline.run_ingest")
     @patch("receipt_index.db.get_connection")
     @patch("receipt_index.store.LocalFileStore")
-    @patch("receipt_index.config.get_store_path")
+    @patch("receipt_index.extraction.create_extraction_agent")
     @patch("receipt_index.adapters.imap.ImapAdapter")
-    @patch("receipt_index.config.get_imap_config")
+    @patch("receipt_index.cli.load_config")
     def test_ingest_dry_run_passes_flag(
         self,
-        mock_imap_config: MagicMock,
+        mock_load_config: MagicMock,
         mock_adapter_cls: MagicMock,
-        mock_store_path: MagicMock,
+        mock_create_agent: MagicMock,
         mock_store_cls: MagicMock,
         mock_get_conn: MagicMock,
         mock_run: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         mock_run.return_value = IngestResult(skipped=5)
         runner = CliRunner()
-        result = runner.invoke(cli, ["ingest", "--dry-run"])
-        assert result.exit_code == 0
+        result = runner.invoke(
+            cli, ["--config", str(config_file), "ingest", "--dry-run"]
+        )
+        assert result.exit_code == 0, result.output
         _, kwargs = mock_run.call_args
         assert kwargs["dry_run"] is True
 
     @patch("receipt_index.pipeline.run_ingest")
     @patch("receipt_index.db.get_connection")
     @patch("receipt_index.store.LocalFileStore")
-    @patch("receipt_index.config.get_store_path")
+    @patch("receipt_index.extraction.create_extraction_agent")
     @patch("receipt_index.adapters.imap.ImapAdapter")
-    @patch("receipt_index.config.get_imap_config")
+    @patch("receipt_index.cli.load_config")
     def test_ingest_limit_passes_value(
         self,
-        mock_imap_config: MagicMock,
+        mock_load_config: MagicMock,
         mock_adapter_cls: MagicMock,
-        mock_store_path: MagicMock,
+        mock_create_agent: MagicMock,
         mock_store_cls: MagicMock,
         mock_get_conn: MagicMock,
         mock_run: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         mock_run.return_value = IngestResult(processed=3)
         runner = CliRunner()
-        result = runner.invoke(cli, ["ingest", "--limit", "3"])
-        assert result.exit_code == 0
+        result = runner.invoke(
+            cli, ["--config", str(config_file), "ingest", "--limit", "3"]
+        )
+        assert result.exit_code == 0, result.output
         _, kwargs = mock_run.call_args
         assert kwargs["limit"] == 3
 
     @patch("receipt_index.pipeline.run_ingest")
     @patch("receipt_index.db.get_connection")
     @patch("receipt_index.store.LocalFileStore")
-    @patch("receipt_index.config.get_store_path")
+    @patch("receipt_index.extraction.create_extraction_agent")
     @patch("receipt_index.adapters.imap.ImapAdapter")
-    @patch("receipt_index.config.get_imap_config")
+    @patch("receipt_index.cli.load_config")
     def test_ingest_exits_1_on_failures(
         self,
-        mock_imap_config: MagicMock,
+        mock_load_config: MagicMock,
         mock_adapter_cls: MagicMock,
-        mock_store_path: MagicMock,
+        mock_create_agent: MagicMock,
         mock_store_cls: MagicMock,
         mock_get_conn: MagicMock,
         mock_run: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         mock_run.return_value = IngestResult(processed=1, failed=2)
         runner = CliRunner()
-        result = runner.invoke(cli, ["ingest"])
+        result = runner.invoke(cli, ["--config", str(config_file), "ingest"])
         assert result.exit_code != 0
+
+    @patch("receipt_index.pipeline.run_ingest")
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.store.LocalFileStore")
+    @patch("receipt_index.extraction.create_extraction_agent")
+    @patch("receipt_index.adapters.imap.ImapAdapter")
+    @patch("receipt_index.cli.load_config")
+    def test_ingest_source_filter(
+        self,
+        mock_load_config: MagicMock,
+        mock_adapter_cls: MagicMock,
+        mock_create_agent: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_conn: MagicMock,
+        mock_run: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
+        mock_run.return_value = IngestResult(processed=2)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--config", str(config_file), "ingest", "--source", "test-email"],
+        )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_run.call_args
+        assert kwargs["source_name"] == "test-email"
+
+    @patch("receipt_index.cli.load_config")
+    def test_ingest_source_not_found(
+        self,
+        mock_load_config: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--config", str(config_file), "ingest", "--source", "nonexistent"],
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    @patch("receipt_index.extraction.create_extraction_agent")
+    @patch("receipt_index.cli.load_config")
+    @patch("receipt_index.pipeline.run_ingest")
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.store.LocalFileStore")
+    @patch("receipt_index.adapters.gdrive.GdriveAdapter", autospec=True)
+    def test_ingest_gdrive_source(
+        self,
+        mock_gdrive_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_conn: MagicMock,
+        mock_run: MagicMock,
+        mock_load_config: MagicMock,
+        mock_create_agent: MagicMock,
+        config_file: Path,
+    ) -> None:
+        """GDrive sources should be ingested via GdriveAdapter."""
+        from receipt_index.config import GdriveSourceConfig
+
+        config = _make_config()
+        gdrive_source = GdriveSourceConfig(
+            name="scanned-receipts",
+            type="gdrive",
+            folder_id="abc123",
+            credentials_json="{}",
+            token_json="{}",
+        )
+        config_with_gdrive = config.model_copy(update={"sources": [gdrive_source]})
+        mock_load_config.return_value = config_with_gdrive
+        mock_run.return_value = IngestResult(processed=0, skipped=0, failed=0)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--config",
+                str(config_file),
+                "ingest",
+                "--source",
+                "scanned-receipts",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_gdrive_cls.assert_called_once_with(gdrive_source)
 
 
 class TestSearchCommand:
@@ -147,27 +305,65 @@ class TestSearchCommand:
 
     @patch("receipt_index.repository.search_receipts", return_value=[_SAMPLE_RECEIPT])
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_search_vendor_filter(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_search: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["search", "--vendor", "amazon"])
-        assert result.exit_code == 0
+        result = runner.invoke(
+            cli, ["--config", str(config_file), "search", "--vendor", "amazon"]
+        )
+        assert result.exit_code == 0, result.output
         _, kwargs = mock_search.call_args
         assert kwargs["vendor"] == "amazon"
 
     @patch("receipt_index.repository.search_receipts", return_value=[_SAMPLE_RECEIPT])
     @patch("receipt_index.db.get_connection")
-    def test_search_json_output(
+    @patch("receipt_index.cli.load_config")
+    def test_search_source_filter(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_search: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["search", "--output", "json"])
-        assert result.exit_code == 0
+        result = runner.invoke(
+            cli,
+            [
+                "--config",
+                str(config_file),
+                "search",
+                "--source",
+                "personal-email",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_search.call_args
+        assert kwargs["source_name"] == "personal-email"
+
+    @patch("receipt_index.repository.search_receipts", return_value=[_SAMPLE_RECEIPT])
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
+    def test_search_json_output(
+        self,
+        mock_load_config: MagicMock,
+        mock_conn: MagicMock,
+        mock_search: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--config", str(config_file), "search", "--output", "json"]
+        )
+        assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert isinstance(data, list)
         assert len(data) == 1
@@ -175,14 +371,18 @@ class TestSearchCommand:
 
     @patch("receipt_index.repository.search_receipts", return_value=[_SAMPLE_RECEIPT])
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_search_text_has_table_headers(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_search: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["search"])
-        assert result.exit_code == 0
+        result = runner.invoke(cli, ["--config", str(config_file), "search"])
+        assert result.exit_code == 0, result.output
         assert "ID" in result.output
         assert "Date" in result.output
         assert "Vendor" in result.output
@@ -191,26 +391,43 @@ class TestSearchCommand:
 
     @patch("receipt_index.repository.search_receipts", return_value=[])
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_search_no_results(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_search: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["search"])
+        result = runner.invoke(cli, ["--config", str(config_file), "search"])
         assert result.exit_code == 0
         assert "No receipts found" in result.output
 
     @patch("receipt_index.repository.search_receipts", return_value=[_SAMPLE_RECEIPT])
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_search_amount_range(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_search: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["search", "--amount-min", "10", "--amount-max", "100"]
+            cli,
+            [
+                "--config",
+                str(config_file),
+                "search",
+                "--amount-min",
+                "10",
+                "--amount-max",
+                "100",
+            ],
         )
         assert result.exit_code == 0
         _, kwargs = mock_search.call_args
@@ -219,30 +436,66 @@ class TestSearchCommand:
 
     @patch("receipt_index.repository.search_receipts", return_value=[_SAMPLE_RECEIPT])
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_search_date_range(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_search: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["search", "--date-from", "2025-01-01", "--date-to", "2025-12-31"],
+            [
+                "--config",
+                str(config_file),
+                "search",
+                "--date-from",
+                "2025-01-01",
+                "--date-to",
+                "2025-12-31",
+            ],
         )
         assert result.exit_code == 0
         _, kwargs = mock_search.call_args
         assert kwargs["date_from"] == date(2025, 1, 1)
         assert kwargs["date_to"] == date(2025, 12, 31)
 
-    def test_search_invalid_amount(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["search", "--amount", "not-a-number"])
-        assert result.exit_code != 0
-
-    def test_search_amount_mutually_exclusive_with_range(self) -> None:
+    @patch("receipt_index.cli.load_config")
+    def test_search_invalid_amount(
+        self,
+        mock_load_config: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["search", "--amount", "42.99", "--amount-min", "10"]
+            cli,
+            ["--config", str(config_file), "search", "--amount", "not-a-number"],
+        )
+        assert result.exit_code != 0
+
+    @patch("receipt_index.cli.load_config")
+    def test_search_amount_mutually_exclusive_with_range(
+        self,
+        mock_load_config: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--config",
+                str(config_file),
+                "search",
+                "--amount",
+                "42.99",
+                "--amount-min",
+                "10",
+            ],
         )
         assert result.exit_code != 0
         assert "--amount cannot be combined" in result.output
@@ -256,13 +509,17 @@ class TestFailuresCommand:
         return_value=[_SAMPLE_FAILURE],
     )
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_failures_text_output(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_get: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["failures"])
+        result = runner.invoke(cli, ["--config", str(config_file), "failures"])
         assert result.exit_code == 0
         assert "noreply@example.com" in result.output
         assert "Your shipping update" in result.output
@@ -273,13 +530,19 @@ class TestFailuresCommand:
         return_value=[_SAMPLE_FAILURE],
     )
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_failures_json_output(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_get: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["failures", "--output", "json"])
+        result = runner.invoke(
+            cli, ["--config", str(config_file), "failures", "--output", "json"]
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert isinstance(data, list)
@@ -289,13 +552,17 @@ class TestFailuresCommand:
 
     @patch("receipt_index.repository.get_ingest_failures", return_value=[])
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_failures_empty(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_get: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["failures"])
+        result = runner.invoke(cli, ["--config", str(config_file), "failures"])
         assert result.exit_code == 0
         assert "No failed ingests" in result.output
 
@@ -305,46 +572,102 @@ class TestShowCommand:
 
     @patch("receipt_index.repository.get_receipt_by_id", return_value=_SAMPLE_RECEIPT)
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_show_text_output(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_get: MagicMock,
+        config_file: Path,
     ) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["show", "019572a0-0000-7000-8000-000000000001"])
-        assert result.exit_code == 0
-        assert "Amazon" in result.output
-        assert "42.99" in result.output
-
-    @patch("receipt_index.repository.get_receipt_by_id", return_value=_SAMPLE_RECEIPT)
-    @patch("receipt_index.db.get_connection")
-    def test_show_json_output(
-        self,
-        mock_conn: MagicMock,
-        mock_get: MagicMock,
-    ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["show", "019572a0-0000-7000-8000-000000000001", "--output", "json"],
+            [
+                "--config",
+                str(config_file),
+                "show",
+                "019572a0-0000-7000-8000-000000000001",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Amazon" in result.output
+        assert "42.99" in result.output
+        assert "Source Name:  personal-email" in result.output
+
+    @patch("receipt_index.repository.get_receipt_by_id", return_value=_SAMPLE_RECEIPT)
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
+    def test_show_json_output(
+        self,
+        mock_load_config: MagicMock,
+        mock_conn: MagicMock,
+        mock_get: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--config",
+                str(config_file),
+                "show",
+                "019572a0-0000-7000-8000-000000000001",
+                "--output",
+                "json",
+            ],
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["vendor"] == "Amazon"
 
-    def test_show_invalid_uuid(self) -> None:
+    @patch("receipt_index.cli.load_config")
+    def test_show_invalid_uuid(
+        self,
+        mock_load_config: MagicMock,
+        config_file: Path,
+    ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["show", "not-a-uuid"])
+        result = runner.invoke(
+            cli, ["--config", str(config_file), "show", "not-a-uuid"]
+        )
         assert result.exit_code != 0
 
     @patch("receipt_index.repository.get_receipt_by_id", return_value=None)
     @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
     def test_show_not_found(
         self,
+        mock_load_config: MagicMock,
         mock_conn: MagicMock,
         mock_get: MagicMock,
+        config_file: Path,
     ) -> None:
+        mock_load_config.return_value = _make_config()
         runner = CliRunner()
-        result = runner.invoke(cli, ["show", "019572a0-0000-7000-8000-000000000099"])
+        result = runner.invoke(
+            cli,
+            [
+                "--config",
+                str(config_file),
+                "show",
+                "019572a0-0000-7000-8000-000000000099",
+            ],
+        )
         assert result.exit_code != 0
         assert "not found" in result.output
+
+
+class TestConfigOption:
+    """Tests for the --config CLI option."""
+
+    def test_missing_config_file_shows_error(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--config", str(tmp_path / "nonexistent.yaml"), "search"]
+        )
+        assert result.exit_code != 0
+        assert "Error" in result.output

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,131 +1,215 @@
-"""Tests for receipt_index.config."""
+"""Tests for receipt_index.config — YAML-based configuration system."""
 
 from __future__ import annotations
+
+import textwrap
+from pathlib import Path  # noqa: TC003
 
 import pytest
 
 from receipt_index.config import (
-    ImapConfig,
-    get_anthropic_api_key,
-    get_imap_config,
-    get_llm_model,
-    get_log_level,
+    AppConfig,
+    ConfigError,
+    ImapSourceConfig,
+    load_config,
+    load_config_dict,
 )
 
 
-class TestGetImapConfig:
-    """Tests for get_imap_config()."""
+class TestImapSourceConfig:
+    """Tests for ImapSourceConfig Pydantic model."""
 
-    def test_valid_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
-        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
-        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
-
-        config = get_imap_config()
-
-        assert config.host == "mail.example.com"
-        assert config.username == "user@example.com"
-        assert config.password == "pass123"  # pragma: allowlist secret
-        assert config.port == 993
-        assert config.folder == "INBOX"
-
-    def test_custom_port_and_folder(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
-        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
-        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
-        monkeypatch.setenv("IMAP_PORT", "143")
-        monkeypatch.setenv("IMAP_FOLDER", "Receipts")
-
-        config = get_imap_config()
-
-        assert config.port == 143
-        assert config.folder == "Receipts"
-
-    def test_missing_host_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("IMAP_HOST", raising=False)
-        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
-        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
-
-        with pytest.raises(ValueError, match="IMAP_HOST"):
-            get_imap_config()
-
-    def test_missing_username_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
-        monkeypatch.delenv("IMAP_USERNAME", raising=False)
-        monkeypatch.setenv("IMAP_PASSWORD", "pass123")  # pragma: allowlist secret
-
-        with pytest.raises(ValueError, match="IMAP_USERNAME"):
-            get_imap_config()
-
-    def test_missing_password_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("IMAP_HOST", "mail.example.com")
-        monkeypatch.setenv("IMAP_USERNAME", "user@example.com")
-        monkeypatch.delenv("IMAP_PASSWORD", raising=False)
-
-        with pytest.raises(ValueError, match="IMAP_PASSWORD"):
-            get_imap_config()
-
-    def test_missing_all_required_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("IMAP_HOST", raising=False)
-        monkeypatch.delenv("IMAP_USERNAME", raising=False)
-        monkeypatch.delenv("IMAP_PASSWORD", raising=False)
-
-        with pytest.raises(
-            ValueError, match=r"IMAP_HOST.*IMAP_USERNAME.*IMAP_PASSWORD"
-        ):
-            get_imap_config()
-
-    def test_config_is_frozen(self) -> None:
-        config = ImapConfig(
+    def test_valid_config(self) -> None:
+        config = ImapSourceConfig(
+            name="personal-email",
             host="mail.example.com",
             username="user@example.com",
-            password="pass",  # pragma: allowlist secret
+            password="secret",  # pragma: allowlist secret
         )
-        with pytest.raises(AttributeError):
-            config.host = "other.example.com"  # type: ignore[misc]
+        assert config.host == "mail.example.com"
+        assert config.port == 993
+        assert config.folder == "INBOX"
+        assert config.use_ssl is True
+
+    def test_custom_port_and_folder(self) -> None:
+        config = ImapSourceConfig(
+            name="work-email",
+            host="mail.example.com",
+            username="user@example.com",
+            password="secret",  # pragma: allowlist secret
+            port=143,
+            folder="Receipts",
+            use_ssl=False,
+        )
+        assert config.port == 143
+        assert config.folder == "Receipts"
+        assert config.use_ssl is False
+
+    def test_name_validation_rejects_uppercase(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            ImapSourceConfig(
+                name="Personal-Email",
+                host="mail.example.com",
+                username="user@example.com",
+                password="secret",  # pragma: allowlist secret
+            )
+
+    def test_name_validation_rejects_spaces(self) -> None:
+        with pytest.raises(Exception):  # noqa: B017
+            ImapSourceConfig(
+                name="my email",
+                host="mail.example.com",
+                username="user@example.com",
+                password="secret",  # pragma: allowlist secret
+            )
 
 
-class TestGetAnthropicApiKey:
-    """Tests for get_anthropic_api_key()."""
+class TestEnvVarInterpolation:
+    """Tests for ${VAR} interpolation in YAML config."""
 
-    def test_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
-        assert get_anthropic_api_key() == "sk-ant-test-key"
+    def test_interpolates_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_PASSWORD", "s3cret")
+        yaml_content = textwrap.dedent("""\
+            sources:
+              - name: test
+                type: imap
+                host: mail.example.com
+                username: user@example.com
+                password: ${TEST_PASSWORD}
+                folder: INBOX
+            database:
+              url: postgresql://localhost/test
+            llm:
+              api_key: test-key
+        """)
+        result = load_config_dict(yaml_content)
+        assert result["sources"][0]["password"] == "s3cret"  # pragma: allowlist secret
 
-    def test_key_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
-            get_anthropic_api_key()
+    def test_missing_env_var_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        yaml_content = textwrap.dedent("""\
+            sources: []
+            database:
+              url: ${MISSING_VAR}
+            llm:
+              api_key: test-key
+        """)
+        with pytest.raises(ConfigError, match="MISSING_VAR"):
+            load_config_dict(yaml_content)
+
+    def test_collects_all_missing_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VAR_A", raising=False)
+        monkeypatch.delenv("VAR_B", raising=False)
+        yaml_content = textwrap.dedent("""\
+            sources: []
+            database:
+              url: ${VAR_A}
+            llm:
+              api_key: ${VAR_B}
+        """)
+        with pytest.raises(ConfigError, match="VAR_A") as exc_info:
+            load_config_dict(yaml_content)
+        assert "VAR_B" in str(exc_info.value)
 
 
-class TestGetLlmModel:
-    """Tests for get_llm_model()."""
+class TestLoadConfig:
+    """Tests for load_config() file discovery and validation."""
 
-    def test_default_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("LLM_MODEL", raising=False)
-        assert get_llm_model() == "claude-haiku-4-5-20251001"
+    def test_load_valid_config(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "receipt-index.yaml"
+        config_file.write_text(
+            textwrap.dedent("""\
+                sources:
+                  - name: test-email
+                    type: imap
+                    host: mail.example.com
+                    username: user@example.com
+                    password: secret
+                    folder: INBOX
+                database:
+                  url: postgresql://localhost/test
+                llm:
+                  api_key: test-key
+            """)
+        )
+        config = load_config(str(config_file))
+        assert isinstance(config, AppConfig)
+        assert len(config.sources) == 1
+        assert isinstance(config.sources[0], ImapSourceConfig)
+        assert config.sources[0].name == "test-email"
+        assert config.database.url == "postgresql://localhost/test"
 
-    def test_custom_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_MODEL", "claude-sonnet-4-20250514")
-        assert get_llm_model() == "claude-sonnet-4-20250514"
+    def test_missing_file_raises(self) -> None:
+        with pytest.raises(ConfigError, match="not found"):
+            load_config("/nonexistent/path/config.yaml")
 
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "bad.yaml"
+        config_file.write_text("not: a: valid: yaml: [")
+        with pytest.raises(ConfigError):
+            load_config(str(config_file))
 
-class TestGetLogLevel:
-    """Tests for get_log_level()."""
+    def test_validation_error_gives_details(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "incomplete.yaml"
+        config_file.write_text(
+            textwrap.dedent("""\
+                sources: []
+            """)
+        )
+        with pytest.raises(ConfigError, match="validation failed"):
+            load_config(str(config_file))
 
-    def test_default_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("LOG_LEVEL", raising=False)
-        assert get_log_level() == "INFO"
+    def test_discovery_via_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_file = tmp_path / "my-config.yaml"
+        config_file.write_text(
+            textwrap.dedent("""\
+                sources:
+                  - name: test-email
+                    type: imap
+                    host: mail.example.com
+                    username: user@example.com
+                    password: secret
+                    folder: INBOX
+                database:
+                  url: postgresql://localhost/test
+                llm:
+                  api_key: test-key
+            """)
+        )
+        monkeypatch.setenv("RECEIPT_INDEX_CONFIG", str(config_file))
+        config = load_config()
+        assert len(config.sources) == 1
 
-    def test_custom_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LOG_LEVEL", "debug")
-        assert get_log_level() == "DEBUG"
+    def test_no_config_found_shows_example(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("RECEIPT_INDEX_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(ConfigError, match="No configuration file found"):
+            load_config()
 
-    def test_uppercase_conversion(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LOG_LEVEL", "Warning")
-        assert get_log_level() == "WARNING"
-
-    def test_invalid_level_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LOG_LEVEL", "VERBOSE")
-        with pytest.raises(ValueError, match="Invalid LOG_LEVEL"):
-            get_log_level()
+    def test_defaults_for_optional_sections(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            textwrap.dedent("""\
+                sources:
+                  - name: test-email
+                    type: imap
+                    host: mail.example.com
+                    username: user@example.com
+                    password: secret
+                    folder: INBOX
+                database:
+                  url: postgresql://localhost/test
+                llm:
+                  api_key: test-key
+            """)
+        )
+        config = load_config(str(config_file))
+        assert config.store.path == "./data/receipts"
+        assert config.logging.level == "INFO"
+        assert config.llm.model == "claude-haiku-4-5-20251001"

--- a/tests/unit/test_config_loading.py
+++ b/tests/unit/test_config_loading.py
@@ -1,0 +1,372 @@
+"""Tests for config file discovery, loading, and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from receipt_index.config import (
+    AppConfig,
+    ConfigError,
+    ImapSourceConfig,
+    _find_config_file,
+    load_config,
+    load_config_dict,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL_YAML = """\
+sources:
+  - name: test-email
+    type: imap
+    host: mail.example.com
+    username: user@example.com
+    password: secret
+    folder: INBOX
+
+database:
+  url: postgresql://localhost/test
+
+llm:
+  api_key: sk-test-key
+"""
+
+_YAML_WITH_ENV_VARS = """\
+sources:
+  - name: test-email
+    type: imap
+    host: mail.example.com
+    username: user@example.com
+    password: ${TEST_IMAP_PASSWORD}
+    folder: INBOX
+
+database:
+  url: ${TEST_DATABASE_URL}
+
+llm:
+  api_key: ${TEST_ANTHROPIC_KEY}
+"""
+
+
+def _write_config(path: Path, content: str = _MINIMAL_YAML) -> Path:
+    """Write config content to a file and return the path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# load_config_dict tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigDict:
+    """Tests for load_config_dict (YAML parsing + env interpolation)."""
+
+    def test_parse_minimal_yaml(self) -> None:
+        result = load_config_dict(_MINIMAL_YAML)
+        assert result["sources"][0]["name"] == "test-email"
+        assert result["database"]["url"] == "postgresql://localhost/test"
+
+    def test_env_var_interpolation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEST_IMAP_PASSWORD", "s3cret")
+        monkeypatch.setenv("TEST_DATABASE_URL", "postgresql://localhost/db")
+        monkeypatch.setenv("TEST_ANTHROPIC_KEY", "sk-ant-xxx")
+
+        result = load_config_dict(_YAML_WITH_ENV_VARS)
+
+        assert result["sources"][0]["password"] == "s3cret"  # pragma: allowlist secret
+        assert result["database"]["url"] == "postgresql://localhost/db"
+        assert result["llm"]["api_key"] == "sk-ant-xxx"  # pragma: allowlist secret
+
+    def test_missing_env_var_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TEST_IMAP_PASSWORD", raising=False)
+        monkeypatch.delenv("TEST_DATABASE_URL", raising=False)
+        monkeypatch.delenv("TEST_ANTHROPIC_KEY", raising=False)
+
+        with pytest.raises(ConfigError, match="TEST_IMAP_PASSWORD"):
+            load_config_dict(_YAML_WITH_ENV_VARS)
+
+    def test_all_missing_env_vars_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All missing env vars should be reported in a single error."""
+        monkeypatch.delenv("TEST_IMAP_PASSWORD", raising=False)
+        monkeypatch.delenv("TEST_DATABASE_URL", raising=False)
+        monkeypatch.delenv("TEST_ANTHROPIC_KEY", raising=False)
+
+        with pytest.raises(ConfigError) as exc_info:
+            load_config_dict(_YAML_WITH_ENV_VARS)
+
+        msg = str(exc_info.value)
+        assert "TEST_IMAP_PASSWORD" in msg
+        assert "TEST_DATABASE_URL" in msg
+        assert "TEST_ANTHROPIC_KEY" in msg
+
+    def test_non_mapping_yaml_raises(self) -> None:
+        with pytest.raises(ConfigError, match="YAML mapping"):
+            load_config_dict("- item1\n- item2\n")
+
+    def test_partial_env_interpolation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Env var in the middle of a string should be interpolated."""
+        yaml_content = """\
+sources:
+  - name: test
+    type: imap
+    host: mail.example.com
+    username: user@example.com
+    password: prefix_${TEST_SUFFIX}_end
+    folder: INBOX
+
+database:
+  url: postgresql://localhost/test
+
+llm:
+  api_key: key
+"""
+        monkeypatch.setenv("TEST_SUFFIX", "middle")
+        result = load_config_dict(yaml_content)
+        assert (
+            result["sources"][0]["password"] == "prefix_middle_end"
+        )  # pragma: allowlist secret
+
+
+# ---------------------------------------------------------------------------
+# _find_config_file tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindConfigFile:
+    """Tests for _find_config_file discovery logic."""
+
+    def test_env_var_takes_precedence(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        env_config = _write_config(tmp_path / "env-config.yaml")
+        _write_config(tmp_path / "receipt-index.yaml")
+        monkeypatch.setenv("RECEIPT_INDEX_CONFIG", str(env_config))
+        monkeypatch.chdir(tmp_path)
+
+        result = _find_config_file()
+
+        assert result == env_config
+
+    def test_cwd_yaml_found(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_config(tmp_path / "receipt-index.yaml")
+        monkeypatch.delenv("RECEIPT_INDEX_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        result = _find_config_file()
+
+        assert result is not None
+        assert result.name == "receipt-index.yaml"
+
+    def test_xdg_config_found(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        xdg_config = tmp_path / ".config" / "receipt-index" / "config.yaml"
+        _write_config(xdg_config)
+        monkeypatch.delenv("RECEIPT_INDEX_CONFIG", raising=False)
+        # chdir to a directory without receipt-index.yaml
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.chdir(empty_dir)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = _find_config_file()
+
+        assert result == xdg_config
+
+    def test_no_config_found_returns_none(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("RECEIPT_INDEX_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = _find_config_file()
+
+        assert result is None
+
+    def test_env_var_points_to_missing_file_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RECEIPT_INDEX_CONFIG", str(tmp_path / "nonexistent.yaml"))
+
+        with pytest.raises(ConfigError, match="does not exist"):
+            _find_config_file()
+
+
+# ---------------------------------------------------------------------------
+# load_config tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    """Tests for load_config (end-to-end loading and validation)."""
+
+    def test_load_with_explicit_path(self, tmp_path: Path) -> None:
+        config_file = _write_config(tmp_path / "config.yaml")
+
+        config = load_config(str(config_file))
+
+        assert isinstance(config, AppConfig)
+        assert len(config.sources) == 1
+        source = config.sources[0]
+        assert isinstance(source, ImapSourceConfig)
+        assert source.name == "test-email"
+        assert source.host == "mail.example.com"
+
+    def test_load_explicit_path_not_found_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match="Config file not found"):
+            load_config(str(tmp_path / "nonexistent.yaml"))
+
+    def test_load_discovers_cwd_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_config(tmp_path / "receipt-index.yaml")
+        monkeypatch.delenv("RECEIPT_INDEX_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        config = load_config()
+
+        assert isinstance(config, AppConfig)
+
+    def test_load_no_config_raises_helpful_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("RECEIPT_INDEX_CONFIG", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with pytest.raises(ConfigError) as exc_info:
+            load_config()
+
+        msg = str(exc_info.value)
+        assert "No configuration file found" in msg
+        assert "RECEIPT_INDEX_CONFIG" in msg
+        assert "receipt-index.yaml" in msg
+        assert "sources:" in msg  # example config is included
+
+    def test_load_with_env_var_interpolation(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_config(tmp_path / "config.yaml", _YAML_WITH_ENV_VARS)
+        monkeypatch.setenv("TEST_IMAP_PASSWORD", "s3cret")
+        monkeypatch.setenv("TEST_DATABASE_URL", "postgresql://localhost/db")
+        monkeypatch.setenv("TEST_ANTHROPIC_KEY", "sk-ant-xxx")
+
+        config = load_config(str(tmp_path / "config.yaml"))
+
+        source = config.sources[0]
+        assert isinstance(source, ImapSourceConfig)
+        assert source.password == "s3cret"  # pragma: allowlist secret
+        assert config.database.url == "postgresql://localhost/db"
+        assert config.llm.api_key == "sk-ant-xxx"  # pragma: allowlist secret
+
+    def test_load_validation_error_raises_config_error(self, tmp_path: Path) -> None:
+        """Invalid Pydantic data should raise ConfigError, not ValidationError."""
+        bad_yaml = """\
+sources:
+  - name: test
+    type: imap
+    # missing required host, username, password
+
+database:
+  url: postgresql://localhost/test
+
+llm:
+  api_key: sk-test
+"""
+        config_file = _write_config(tmp_path / "config.yaml", bad_yaml)
+
+        with pytest.raises(ConfigError, match="Config validation failed"):
+            load_config(str(config_file))
+
+    def test_load_defaults_applied(self, tmp_path: Path) -> None:
+        config_file = _write_config(tmp_path / "config.yaml")
+
+        config = load_config(str(config_file))
+
+        assert config.store.path == "./data/receipts"
+        assert config.logging.level == "INFO"
+        assert config.llm.model == "claude-haiku-4-5-20251001"
+        source = config.sources[0]
+        assert isinstance(source, ImapSourceConfig)
+        assert source.port == 993
+        assert source.use_ssl is True
+
+    def test_source_name_validation(self, tmp_path: Path) -> None:
+        """Source names must match ^[a-z0-9][a-z0-9-]*$."""
+        bad_name_yaml = """\
+sources:
+  - name: Invalid_Name!
+    type: imap
+    host: mail.example.com
+    username: user@example.com
+    password: secret
+    folder: INBOX
+
+database:
+  url: postgresql://localhost/test
+
+llm:
+  api_key: sk-test
+"""
+        config_file = _write_config(tmp_path / "config.yaml", bad_name_yaml)
+
+        with pytest.raises(ConfigError, match="Config validation failed"):
+            load_config(str(config_file))
+
+    def test_multiple_sources(self, tmp_path: Path) -> None:
+        multi_yaml = """\
+sources:
+  - name: email-1
+    type: imap
+    host: mail1.example.com
+    username: user1@example.com
+    password: pass1
+    folder: INBOX
+
+  - name: email-2
+    type: imap
+    host: mail2.example.com
+    username: user2@example.com
+    password: pass2
+    folder: Receipts
+
+database:
+  url: postgresql://localhost/test
+
+llm:
+  api_key: sk-test
+"""
+        config_file = _write_config(tmp_path / "config.yaml", multi_yaml)
+
+        config = load_config(str(config_file))
+
+        assert len(config.sources) == 2
+        assert config.sources[0].name == "email-1"
+        assert config.sources[1].name == "email-2"

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -6,9 +6,13 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from receipt_index.extraction import (
     _build_prompt,
+    _extract_from_document,
     _extract_pdf_text,
+    _has_sufficient_text,
     _strip_html_tags,
     extract_metadata,
 )
@@ -32,6 +36,8 @@ class TestBuildPrompt:
     def test_strips_html_when_no_text_body(self) -> None:
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="HTML Receipt",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -45,6 +51,8 @@ class TestBuildPrompt:
     def test_prefers_text_over_html(self) -> None:
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Both",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -58,6 +66,8 @@ class TestBuildPrompt:
     def test_handles_no_body(self) -> None:
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Empty",
             sender="x@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -182,6 +192,8 @@ class TestExtractMetadata:
     def test_includes_pdf_text_in_prompt(self, _mock_pdf_extract: MagicMock) -> None:
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Receipt",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -250,3 +262,191 @@ class TestExtractPdfText:
         result = _extract_pdf_text(attachments)
         assert result == "first pdf text"
         mock_extract.assert_called_once_with(b"%PDF-first")
+
+
+class TestHasSufficientText:
+    """Tests for _has_sufficient_text."""
+
+    def test_sufficient_text(self) -> None:
+        assert _has_sufficient_text("A" * 20) is True
+
+    def test_insufficient_text(self) -> None:
+        assert _has_sufficient_text("short") is False
+
+    def test_whitespace_stripped(self) -> None:
+        # 10 chars with spaces should not count as 20
+        assert _has_sufficient_text("a b c d e f g h i j") is False
+
+    def test_empty_string(self) -> None:
+        assert _has_sufficient_text("") is False
+
+
+class TestExtractMetadataRouting:
+    """Tests for source_type routing in extract_metadata."""
+
+    def _mock_agent(self) -> MagicMock:
+        mock_result = MagicMock()
+        mock_result.output = ReceiptMetadata(
+            vendor="TestVendor",
+            amount=Decimal("10.00"),
+            date=date(2025, 1, 1),
+            confidence=0.9,
+        )
+        agent = MagicMock()
+        agent.run_sync.return_value = mock_result
+        return agent
+
+    def test_email_source_uses_email_path(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            source_type="imap",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            subject="Receipt",
+            sender="shop@example.com",
+            text_body="Total: $10.00",
+        )
+        agent = self._mock_agent()
+        result = extract_metadata(raw, agent=agent)
+
+        assert result.vendor == "TestVendor"
+        # Email path sends a string prompt, not a list
+        prompt = agent.run_sync.call_args[0][0]
+        assert isinstance(prompt, str)
+        assert "Subject: Receipt" in prompt
+
+    @patch(
+        "receipt_index.pdf_reader.extract_text",
+        return_value="Vendor: Shop Total: $25",
+    )
+    def test_gdrive_source_uses_document_path(self, _mock_extract: MagicMock) -> None:
+        raw = RawReceipt(
+            source_id="drive-file-1",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=b"%PDF-test-content",
+            file_content_type="application/pdf",
+        )
+        agent = self._mock_agent()
+        result = extract_metadata(raw, agent=agent)
+
+        assert result.vendor == "TestVendor"
+        # PDF with sufficient text sends a text prompt
+        prompt = agent.run_sync.call_args[0][0]
+        assert isinstance(prompt, str)
+        assert "Vendor: Shop" in prompt
+
+
+class TestExtractFromDocument:
+    """Tests for _extract_from_document."""
+
+    def _mock_agent(self) -> MagicMock:
+        mock_result = MagicMock()
+        mock_result.output = ReceiptMetadata(
+            vendor="Store",
+            amount=Decimal("15.00"),
+            date=date(2025, 3, 1),
+            confidence=0.85,
+        )
+        agent = MagicMock()
+        agent.run_sync.return_value = mock_result
+        return agent
+
+    def test_raises_without_file_content(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=None,
+            file_content_type="application/pdf",
+        )
+        with pytest.raises(ValueError, match="no file_content"):
+            _extract_from_document(raw, agent=self._mock_agent())
+
+    def test_raises_for_unsupported_content_type(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=b"data",
+            file_content_type="text/plain",
+        )
+        with pytest.raises(ValueError, match="Unsupported file content type"):
+            _extract_from_document(raw, agent=self._mock_agent())
+
+    @patch(
+        "receipt_index.pdf_reader.extract_text",
+        return_value="Sufficient text content that is longer than 20 chars",
+    )
+    def test_pdf_with_sufficient_text_uses_text_path(
+        self, mock_extract: MagicMock
+    ) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=b"%PDF-test",
+            file_content_type="application/pdf",
+        )
+        agent = self._mock_agent()
+        _extract_from_document(raw, agent=agent)
+
+        mock_extract.assert_called_once_with(b"%PDF-test")
+        prompt = agent.run_sync.call_args[0][0]
+        assert isinstance(prompt, str)
+        assert "Sufficient text content" in prompt
+
+    @patch("receipt_index.pdf_reader.extract_text", return_value="short")
+    def test_pdf_with_insufficient_text_uses_vision(
+        self, _mock_extract: MagicMock
+    ) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=b"%PDF-scanned",
+            file_content_type="application/pdf",
+        )
+        agent = self._mock_agent()
+        _extract_from_document(raw, agent=agent)
+
+        # Vision path sends a list with BinaryContent
+        call_args = agent.run_sync.call_args[0][0]
+        assert isinstance(call_args, list)
+        assert len(call_args) == 2
+
+    def test_image_jpeg_uses_vision(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=b"\xff\xd8\xff\xe0fake-jpeg",
+            file_content_type="image/jpeg",
+        )
+        agent = self._mock_agent()
+        _extract_from_document(raw, agent=agent)
+
+        call_args = agent.run_sync.call_args[0][0]
+        assert isinstance(call_args, list)
+        assert len(call_args) == 2
+
+    def test_image_png_uses_vision(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            source_type="gdrive",
+            file_content=b"\x89PNGfake-png",
+            file_content_type="image/png",
+        )
+        agent = self._mock_agent()
+        _extract_from_document(raw, agent=agent)
+
+        call_args = agent.run_sync.call_args[0][0]
+        assert isinstance(call_args, list)

--- a/tests/unit/test_gdrive_adapter.py
+++ b/tests/unit/test_gdrive_adapter.py
@@ -1,0 +1,395 @@
+"""Tests for receipt_index.adapters.gdrive."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from receipt_index.adapters.gdrive import GdriveAdapter, _parse_drive_date
+from receipt_index.config import GdriveSourceConfig
+
+
+def _make_gdrive_config(
+    *,
+    name: str = "test-drive",
+    folder_id: str = "folder_abc123",
+) -> GdriveSourceConfig:
+    """Build a GdriveSourceConfig with fake credential JSON."""
+    credentials_json = json.dumps(
+        {
+            "installed": {
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",  # pragma: allowlist secret
+            }
+        }
+    )
+    token_json = json.dumps(
+        {
+            "token": "fake-access-token",
+            "refresh_token": "fake-refresh-token",
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",  # pragma: allowlist secret
+        }
+    )
+    return GdriveSourceConfig(
+        name=name,
+        folder_id=folder_id,
+        credentials_json=credentials_json,
+        token_json=token_json,
+    )
+
+
+def _make_file_meta(
+    *,
+    file_id: str = "file_1",
+    name: str = "receipt.pdf",
+    mime_type: str = "application/pdf",
+    modified_time: str = "2024-01-15T10:30:00.000Z",
+) -> dict[str, Any]:
+    """Build a Drive API file metadata dict."""
+    return {
+        "id": file_id,
+        "name": name,
+        "mimeType": mime_type,
+        "modifiedTime": modified_time,
+    }
+
+
+def _mock_drive_service(
+    files: list[dict[str, Any]] | None = None,
+    *,
+    pages: list[list[dict[str, Any]]] | None = None,
+    download_content: bytes = b"file-content",
+) -> MagicMock:
+    """Create a mock Google Drive service.
+
+    Args:
+        files: Single page of file metadata (convenience for single-page tests).
+        pages: Multiple pages of file metadata for pagination tests.
+        download_content: Bytes returned by get_media/export_media.
+    """
+    service = MagicMock()
+
+    if pages is not None:
+        # Multi-page responses
+        responses = []
+        for i, page_files in enumerate(pages):
+            resp: dict[str, Any] = {"files": page_files}
+            if i < len(pages) - 1:
+                resp["nextPageToken"] = f"token_{i + 1}"
+            responses.append(resp)
+        service.files().list().execute.side_effect = responses
+        # Chain the list mock so each call returns a new mock with execute
+        list_mocks = []
+        for resp in responses:
+            m = MagicMock()
+            m.execute.return_value = resp
+            list_mocks.append(m)
+        service.files().list.side_effect = list_mocks
+    else:
+        # Single-page response
+        response: dict[str, Any] = {"files": files or []}
+        list_mock = MagicMock()
+        list_mock.execute.return_value = response
+        service.files().list.return_value = list_mock
+
+    # Download mocks
+    get_media_mock = MagicMock()
+    get_media_mock.execute.return_value = download_content
+    service.files().get_media.return_value = get_media_mock
+
+    export_media_mock = MagicMock()
+    export_media_mock.execute.return_value = download_content
+    service.files().export_media.return_value = export_media_mock
+
+    return service
+
+
+class TestParseDriveDate:
+    """Tests for _parse_drive_date."""
+
+    def test_parses_standard_drive_timestamp(self) -> None:
+        result = _parse_drive_date("2024-01-15T10:30:00.000Z")
+        assert result == datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
+
+    def test_parses_without_fractional_seconds(self) -> None:
+        result = _parse_drive_date("2024-06-01T00:00:00Z")
+        assert result == datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+
+    def test_parses_with_microseconds(self) -> None:
+        result = _parse_drive_date("2024-12-31T23:59:59.123456Z")
+        expected = datetime(2024, 12, 31, 23, 59, 59, 123456, tzinfo=UTC)
+        assert result == expected
+
+    def test_result_is_utc(self) -> None:
+        result = _parse_drive_date("2024-01-15T10:30:00.000Z")
+        assert result.tzinfo is UTC
+
+
+class TestBuildService:
+    """Tests for _build_service credential building."""
+
+    @patch("google.oauth2.credentials.Credentials.from_authorized_user_info")
+    @patch("googleapiclient.discovery.build")
+    def test_builds_service_from_token_json(
+        self,
+        mock_build: MagicMock,
+        mock_from_user_info: MagicMock,
+    ) -> None:
+        config = _make_gdrive_config()
+        creds = MagicMock()
+        creds.expired = False
+        mock_from_user_info.return_value = creds
+
+        expected_service = MagicMock()
+        mock_build.return_value = expected_service
+
+        adapter = GdriveAdapter(config)
+        service = adapter._build_service()
+
+        token_data = json.loads(config.token_json)
+        mock_from_user_info.assert_called_once_with(token_data)
+        mock_build.assert_called_once_with("drive", "v3", credentials=creds)
+        assert service is expected_service
+
+    @patch("googleapiclient.discovery.build")
+    @patch("google.auth.transport.requests.Request")
+    @patch("google.oauth2.credentials.Credentials.from_authorized_user_info")
+    def test_refreshes_expired_credentials(
+        self,
+        mock_from_user_info: MagicMock,
+        mock_request_cls: MagicMock,
+        mock_build: MagicMock,
+    ) -> None:
+        config = _make_gdrive_config()
+        creds = MagicMock()
+        creds.expired = True
+        creds.refresh_token = "fake-refresh"
+        mock_from_user_info.return_value = creds
+
+        adapter = GdriveAdapter(config)
+        adapter._build_service()
+
+        creds.refresh.assert_called_once_with(mock_request_cls())
+
+    @patch("googleapiclient.discovery.build")
+    @patch("google.oauth2.credentials.Credentials.from_authorized_user_info")
+    def test_does_not_refresh_when_not_expired(
+        self,
+        mock_from_user_info: MagicMock,
+        mock_build: MagicMock,
+    ) -> None:
+        config = _make_gdrive_config()
+        creds = MagicMock()
+        creds.expired = False
+        mock_from_user_info.return_value = creds
+
+        adapter = GdriveAdapter(config)
+        adapter._build_service()
+
+        creds.refresh.assert_not_called()
+
+
+class TestListFiles:
+    """Tests for _list_files."""
+
+    def test_lists_files_single_page(self) -> None:
+        config = _make_gdrive_config(folder_id="folder_xyz")
+        files = [
+            _make_file_meta(file_id="f1", name="receipt1.pdf"),
+            _make_file_meta(file_id="f2", name="receipt2.jpg"),
+        ]
+        service = _mock_drive_service(files=files)
+
+        adapter = GdriveAdapter(config)
+        result = adapter._list_files(service)
+
+        assert len(result) == 2
+        assert result[0]["id"] == "f1"
+        assert result[1]["id"] == "f2"
+
+        # Verify query includes folder_id
+        call_kwargs = service.files().list.call_args
+        assert "folder_xyz" in call_kwargs.kwargs.get("q", call_kwargs[1].get("q", ""))
+
+    def test_handles_pagination(self) -> None:
+        config = _make_gdrive_config()
+        page1 = [_make_file_meta(file_id="f1")]
+        page2 = [_make_file_meta(file_id="f2")]
+        service = _mock_drive_service(pages=[page1, page2])
+
+        adapter = GdriveAdapter(config)
+        result = adapter._list_files(service)
+
+        assert len(result) == 2
+        assert result[0]["id"] == "f1"
+        assert result[1]["id"] == "f2"
+
+    def test_empty_folder(self) -> None:
+        config = _make_gdrive_config()
+        service = _mock_drive_service(files=[])
+
+        adapter = GdriveAdapter(config)
+        result = adapter._list_files(service)
+
+        assert result == []
+
+
+class TestDownloadFile:
+    """Tests for _download_file."""
+
+    def test_downloads_pdf(self) -> None:
+        config = _make_gdrive_config()
+        pdf_content = b"%PDF-1.4 content"
+        service = _mock_drive_service(download_content=pdf_content)
+        file_meta = _make_file_meta(mime_type="application/pdf")
+
+        adapter = GdriveAdapter(config)
+        result = adapter._download_file(service, file_meta)
+
+        assert result is not None
+        content, mime_type = result
+        assert content == pdf_content
+        assert mime_type == "application/pdf"
+        service.files().get_media.assert_called_once_with(fileId="file_1")
+
+    def test_downloads_jpeg(self) -> None:
+        config = _make_gdrive_config()
+        img_content = b"\xff\xd8\xff\xe0 jpeg data"
+        service = _mock_drive_service(download_content=img_content)
+        file_meta = _make_file_meta(mime_type="image/jpeg", name="scan.jpg")
+
+        adapter = GdriveAdapter(config)
+        result = adapter._download_file(service, file_meta)
+
+        assert result is not None
+        content, mime_type = result
+        assert content == img_content
+        assert mime_type == "image/jpeg"
+
+    def test_downloads_png(self) -> None:
+        config = _make_gdrive_config()
+        img_content = b"\x89PNG\r\n\x1a\n"
+        service = _mock_drive_service(download_content=img_content)
+        file_meta = _make_file_meta(mime_type="image/png", name="scan.png")
+
+        adapter = GdriveAdapter(config)
+        result = adapter._download_file(service, file_meta)
+
+        assert result is not None
+        content, mime_type = result
+        assert content == img_content
+        assert mime_type == "image/png"
+
+    def test_exports_google_doc_as_pdf(self) -> None:
+        config = _make_gdrive_config()
+        pdf_content = b"%PDF-1.4 exported"
+        service = _mock_drive_service(download_content=pdf_content)
+        file_meta = _make_file_meta(
+            mime_type="application/vnd.google-apps.document",
+            name="My Document",
+        )
+
+        adapter = GdriveAdapter(config)
+        result = adapter._download_file(service, file_meta)
+
+        assert result is not None
+        content, mime_type = result
+        assert content == pdf_content
+        assert mime_type == "application/pdf"
+        service.files().export_media.assert_called_once_with(
+            fileId="file_1", mimeType="application/pdf"
+        )
+
+    def test_skips_unsupported_mime_type(self) -> None:
+        config = _make_gdrive_config()
+        service = _mock_drive_service()
+        file_meta = _make_file_meta(mime_type="application/zip", name="archive.zip")
+
+        adapter = GdriveAdapter(config)
+        result = adapter._download_file(service, file_meta)
+
+        assert result is None
+
+
+class TestFetchUnprocessed:
+    """Tests for the full fetch_unprocessed flow."""
+
+    def test_yields_unprocessed_files(self) -> None:
+        config = _make_gdrive_config(name="my-drive")
+        files = [
+            _make_file_meta(file_id="f1", name="receipt1.pdf"),
+            _make_file_meta(
+                file_id="f2",
+                name="receipt2.jpg",
+                mime_type="image/jpeg",
+                modified_time="2024-03-20T15:00:00.000Z",
+            ),
+        ]
+        pdf_content = b"%PDF-1.4"
+        service = _mock_drive_service(files=files, download_content=pdf_content)
+
+        adapter = GdriveAdapter(config)
+        adapter._build_service = MagicMock(return_value=service)  # type: ignore[method-assign]
+        results = list(adapter.fetch_unprocessed(set()))
+
+        assert len(results) == 2
+        assert results[0].source_id == "f1"
+        assert results[0].source_name == "my-drive"
+        assert results[0].source_type == "gdrive"
+        assert results[0].file_name == "receipt1.pdf"
+        assert results[0].file_content == pdf_content
+        assert results[0].file_content_type == "application/pdf"
+
+        assert results[1].source_id == "f2"
+        assert results[1].date == datetime(2024, 3, 20, 15, 0, 0, tzinfo=UTC)
+
+    def test_skips_already_processed_files(self) -> None:
+        config = _make_gdrive_config()
+        files = [
+            _make_file_meta(file_id="f1"),
+            _make_file_meta(file_id="f2"),
+            _make_file_meta(file_id="f3"),
+        ]
+        service = _mock_drive_service(files=files, download_content=b"data")
+
+        adapter = GdriveAdapter(config)
+        adapter._build_service = MagicMock(return_value=service)  # type: ignore[method-assign]
+        results = list(adapter.fetch_unprocessed({"f1", "f3"}))
+
+        assert len(results) == 1
+        assert results[0].source_id == "f2"
+
+    def test_skips_unsupported_files_in_flow(self) -> None:
+        config = _make_gdrive_config()
+        files = [
+            _make_file_meta(file_id="f1", mime_type="application/pdf"),
+            _make_file_meta(file_id="f2", mime_type="application/zip", name="data.zip"),
+        ]
+        service = _mock_drive_service(files=files, download_content=b"pdf-data")
+
+        adapter = GdriveAdapter(config)
+        adapter._build_service = MagicMock(return_value=service)  # type: ignore[method-assign]
+        results = list(adapter.fetch_unprocessed(set()))
+
+        assert len(results) == 1
+        assert results[0].source_id == "f1"
+
+    def test_empty_folder_yields_nothing(self) -> None:
+        config = _make_gdrive_config()
+        service = _mock_drive_service(files=[])
+
+        adapter = GdriveAdapter(config)
+        adapter._build_service = MagicMock(return_value=service)  # type: ignore[method-assign]
+        results = list(adapter.fetch_unprocessed(set()))
+
+        assert results == []
+
+    def test_conforms_to_source_adapter_protocol(self) -> None:
+        from receipt_index.adapters.base import SourceAdapter
+
+        config = _make_gdrive_config()
+        adapter = GdriveAdapter(config)
+        assert isinstance(adapter, SourceAdapter)

--- a/tests/unit/test_gdrive_adapter.py
+++ b/tests/unit/test_gdrive_adapter.py
@@ -17,14 +17,6 @@ def _make_gdrive_config(
     folder_id: str = "folder_abc123",
 ) -> GdriveSourceConfig:
     """Build a GdriveSourceConfig with fake credential JSON."""
-    credentials_json = json.dumps(
-        {
-            "installed": {
-                "client_id": "test-client-id",
-                "client_secret": "test-client-secret",  # pragma: allowlist secret
-            }
-        }
-    )
     token_json = json.dumps(
         {
             "token": "fake-access-token",
@@ -36,7 +28,6 @@ def _make_gdrive_config(
     return GdriveSourceConfig(
         name=name,
         folder_id=folder_id,
-        credentials_json=credentials_json,
         token_json=token_json,
     )
 

--- a/tests/unit/test_image_converter.py
+++ b/tests/unit/test_image_converter.py
@@ -1,0 +1,59 @@
+"""Tests for receipt_index.image_converter."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from receipt_index.image_converter import image_to_pdf
+
+
+def _make_image(
+    fmt: str,
+    mode: str = "RGB",
+    size: tuple[int, int] = (100, 80),
+) -> bytes:
+    """Create minimal image bytes for testing."""
+    img = Image.new(mode, size, color="red")
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestImageToPdf:
+    """Tests for the image_to_pdf function."""
+
+    def test_jpeg_produces_valid_pdf(self) -> None:
+        jpeg_data = _make_image("JPEG")
+        result = image_to_pdf(jpeg_data)
+        assert result[:5] == b"%PDF-"
+
+    def test_png_produces_valid_pdf(self) -> None:
+        png_data = _make_image("PNG")
+        result = image_to_pdf(png_data)
+        assert result[:5] == b"%PDF-"
+
+    def test_rgba_png_converts_to_rgb(self) -> None:
+        rgba_data = _make_image("PNG", mode="RGBA")
+        result = image_to_pdf(rgba_data)
+        assert result[:5] == b"%PDF-"
+
+    def test_la_mode_converts_to_rgb(self) -> None:
+        la_data = _make_image("PNG", mode="LA")
+        result = image_to_pdf(la_data)
+        assert result[:5] == b"%PDF-"
+
+    def test_unsupported_format_raises_value_error(self) -> None:
+        bmp_data = _make_image("BMP")
+        with pytest.raises(ValueError, match="Unsupported image format"):
+            image_to_pdf(bmp_data)
+
+    def test_invalid_data_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unable to decode image data"):
+            image_to_pdf(b"not-an-image")
+
+    def test_empty_data_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unable to decode image data"):
+            image_to_pdf(b"")

--- a/tests/unit/test_imap_adapter.py
+++ b/tests/unit/test_imap_adapter.py
@@ -16,7 +16,7 @@ import pytest
 from receipt_index.adapters.imap import ImapAdapter
 
 if TYPE_CHECKING:
-    from receipt_index.config import ImapConfig
+    from receipt_index.config import ImapSourceConfig
 
 
 def _make_simple_email(
@@ -245,7 +245,7 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_yields_unprocessed_messages(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         email1 = _make_simple_email(
             message_id="<msg-1@example.com>", subject="Receipt 1"
@@ -266,7 +266,7 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_skips_processed_messages(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         email1 = _make_simple_email(
             message_id="<msg-1@example.com>", subject="Receipt 1"
@@ -285,7 +285,9 @@ class TestFetchUnprocessed:
         assert results[0].source_id == "<msg-2@example.com>"
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
-    def test_empty_folder(self, mock_ssl: MagicMock, imap_config: ImapConfig) -> None:
+    def test_empty_folder(
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
+    ) -> None:
         conn = self._mock_imap_connection({})
         mock_ssl.return_value = conn
 
@@ -296,7 +298,7 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_logout_called_on_success(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         conn = self._mock_imap_connection({})
         mock_ssl.return_value = conn
@@ -308,7 +310,7 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_logout_called_on_error(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         conn = MagicMock()
         conn.select.side_effect = Exception("Connection lost")
@@ -322,7 +324,7 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_connection_uses_config(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         conn = self._mock_imap_connection({})
         mock_ssl.return_value = conn
@@ -336,11 +338,9 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4")
     def test_plain_imap_when_ssl_disabled(
-        self, mock_imap: MagicMock, imap_config: ImapConfig
+        self, mock_imap: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
-        from dataclasses import replace
-
-        plain_config = replace(imap_config, use_ssl=False, port=143)
+        plain_config = imap_config.model_copy(update={"use_ssl": False, "port": 143})
         conn = self._mock_imap_connection({})
         mock_imap.return_value = conn
 
@@ -352,7 +352,7 @@ class TestFetchUnprocessed:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_parses_email_fields(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         email_bytes = _make_simple_email(
             subject="Your Order",
@@ -382,7 +382,7 @@ class TestConnectRetry:
     @patch("receipt_index.adapters.imap.time.sleep")
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_retries_on_connection_failure(
-        self, mock_ssl: MagicMock, mock_sleep: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, mock_sleep: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         conn = MagicMock()
         conn.select.return_value = ("OK", [b"1"])
@@ -402,7 +402,7 @@ class TestConnectRetry:
     @patch("receipt_index.adapters.imap.time.sleep")
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_raises_after_max_retries(
-        self, mock_ssl: MagicMock, mock_sleep: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, mock_sleep: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         mock_ssl.side_effect = OSError("connection refused")
 
@@ -415,7 +415,7 @@ class TestConnectRetry:
 
     @patch("receipt_index.adapters.imap.imaplib.IMAP4_SSL")
     def test_imap_error_not_retried(
-        self, mock_ssl: MagicMock, imap_config: ImapConfig
+        self, mock_ssl: MagicMock, imap_config: ImapSourceConfig
     ) -> None:
         """IMAP protocol/auth errors should propagate immediately, not retry."""
         mock_ssl.side_effect = imaplib.IMAP4.error("auth fail")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -50,14 +50,14 @@ class TestReceiptMetadata:
                 confidence=0.9,
             )
 
-    def test_zero_amount_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="amount"):
-            ReceiptMetadata(
-                vendor="Amazon",
-                amount=Decimal("0"),
-                date=date(2025, 6, 15),
-                confidence=0.9,
-            )
+    def test_zero_amount_accepted(self) -> None:
+        meta = ReceiptMetadata(
+            vendor="Amazon",
+            amount=Decimal("0"),
+            date=date(2025, 6, 15),
+            confidence=0.9,
+        )
+        assert meta.amount == Decimal("0")
 
     def test_empty_vendor_rejected(self) -> None:
         with pytest.raises(ValidationError, match="vendor"):
@@ -162,6 +162,7 @@ class TestReceipt:
             id=uuid4(),
             source_id="msg-123",
             source_type="imap",
+            source_name="test-email",
             vendor="Amazon",
             amount=Decimal("42.99"),
             currency="USD",
@@ -186,6 +187,7 @@ class TestReceipt:
             id=uuid4(),
             source_id="msg-456",
             source_type="imap",
+            source_name="test-email",
             vendor="Costco",
             amount=Decimal("157.32"),
             currency="USD",

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -15,6 +15,7 @@ _RECEIPT_ROW: dict[str, Any] = {
     "id": UUID("019572a0-0000-7000-8000-000000000001"),
     "source_id": "<msg-1@example.com>",
     "source_type": "imap",
+    "source_name": "personal-email",
     "vendor": "Amazon",
     "amount": Decimal("42.99"),
     "currency": "USD",
@@ -25,6 +26,7 @@ _RECEIPT_ROW: dict[str, Any] = {
     "email_subject": "Your Amazon.com order",
     "email_sender": "no-reply@amazon.com",
     "email_date": datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
+    "file_name": None,
     "created_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
     "updated_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
 }
@@ -41,12 +43,18 @@ _SAMPLE_METADATA = ReceiptMetadata(
 )
 
 
-def _make_raw(source_id: str = "<msg-1@example.com>") -> RawReceipt:
+def _make_raw(
+    source_id: str = "<msg-1@example.com>",
+    source_name: str = "personal-email",
+    source_type: str = "imap",
+) -> RawReceipt:
     return RawReceipt(
         source_id=source_id,
+        source_name=source_name,
+        source_type=source_type,
+        date=datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
         subject="Your Amazon.com order",
         sender="no-reply@amazon.com",
-        date=datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
         text_body="Order Total: $42.99",
     )
 
@@ -92,7 +100,9 @@ class TestRunIngest:
         adapter = _mock_adapter([_make_raw()])
         store = _mock_store()
 
-        result = run_ingest(conn=conn, adapter=adapter, store=store)
+        result = run_ingest(
+            conn=conn, adapter=adapter, store=store, source_name="test-imap"
+        )
 
         assert result.processed == 1
         assert result.skipped == 0
@@ -112,7 +122,13 @@ class TestRunIngest:
         adapter = _mock_adapter([_make_raw(), _make_raw("<msg-2@example.com>")])
         store = _mock_store()
 
-        result = run_ingest(conn=conn, adapter=adapter, store=store, dry_run=True)
+        result = run_ingest(
+            conn=conn,
+            adapter=adapter,
+            store=store,
+            source_name="test-imap",
+            dry_run=True,
+        )
 
         assert result.processed == 0
         assert result.skipped == 2
@@ -136,7 +152,13 @@ class TestRunIngest:
         adapter = _mock_adapter(raws)
         store = _mock_store()
 
-        result = run_ingest(conn=conn, adapter=adapter, store=store, limit=2)
+        result = run_ingest(
+            conn=conn,
+            adapter=adapter,
+            store=store,
+            source_name="test-imap",
+            limit=2,
+        )
 
         assert result.processed == 2
 
@@ -156,7 +178,9 @@ class TestRunIngest:
         adapter = _mock_adapter([_make_raw(), _make_raw("<msg-2@example.com>")])
         store = _mock_store()
 
-        result = run_ingest(conn=conn, adapter=adapter, store=store)
+        result = run_ingest(
+            conn=conn, adapter=adapter, store=store, source_name="test-imap"
+        )
 
         assert result.failed == 2
         assert result.processed == 0
@@ -183,7 +207,13 @@ class TestRunIngest:
         store = _mock_store()
         mock_agent = MagicMock()
 
-        run_ingest(conn=conn, adapter=adapter, store=store, agent=mock_agent)
+        run_ingest(
+            conn=conn,
+            adapter=adapter,
+            store=store,
+            source_name="test-imap",
+            agent=mock_agent,
+        )
 
         mock_extract.assert_called_once()
         _, kwargs = mock_extract.call_args

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -101,7 +101,11 @@ class TestRunIngest:
         store = _mock_store()
 
         result = run_ingest(
-            conn=conn, adapter=adapter, store=store, source_name="test-imap"
+            conn=conn,
+            adapter=adapter,
+            store=store,
+            source_name="test-imap",
+            source_type="imap",
         )
 
         assert result.processed == 1
@@ -127,6 +131,7 @@ class TestRunIngest:
             adapter=adapter,
             store=store,
             source_name="test-imap",
+            source_type="imap",
             dry_run=True,
         )
 
@@ -157,6 +162,7 @@ class TestRunIngest:
             adapter=adapter,
             store=store,
             source_name="test-imap",
+            source_type="imap",
             limit=2,
         )
 
@@ -179,7 +185,11 @@ class TestRunIngest:
         store = _mock_store()
 
         result = run_ingest(
-            conn=conn, adapter=adapter, store=store, source_name="test-imap"
+            conn=conn,
+            adapter=adapter,
+            store=store,
+            source_name="test-imap",
+            source_type="imap",
         )
 
         assert result.failed == 2
@@ -212,6 +222,7 @@ class TestRunIngest:
             adapter=adapter,
             store=store,
             source_name="test-imap",
+            source_type="imap",
             agent=mock_agent,
         )
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -15,6 +15,7 @@ from receipt_index.renderer import (
     _find_pdf_attachment,
     _html_to_pdf_bytes,
     _html_to_pdf_weasyprint,
+    _render_drive_file,
     _render_text_to_pdf,
     render_pdf,
 )
@@ -27,6 +28,8 @@ class TestRenderPdf:
         pdf_data = b"%PDF-1.4 test content"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Receipt",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -46,6 +49,8 @@ class TestRenderPdf:
         mock_pdf.return_value = b"pdf-from-html"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="HTML Receipt",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -60,6 +65,8 @@ class TestRenderPdf:
         mock_pdf.return_value = b"pdf-from-text"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Text Receipt",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -73,6 +80,8 @@ class TestRenderPdf:
         mock_pdf.return_value = b"pdf-fallback"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Empty",
             sender="x@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -84,6 +93,8 @@ class TestRenderPdf:
         pdf_data = b"%PDF-1.4 original"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Receipt",
             sender="shop@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -203,6 +214,8 @@ class TestRenderTextToPdf:
         mock_pdf.return_value = b"pdf-bytes"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="My Receipt",
             sender="shop@example.com",
             date=datetime(2025, 3, 15, tzinfo=UTC),
@@ -221,6 +234,8 @@ class TestRenderTextToPdf:
         mock_pdf.return_value = b"pdf-bytes"
         raw = RawReceipt(
             source_id="test",
+            source_name="test-source",
+            source_type="imap",
             subject="Test",
             sender="x@example.com",
             date=datetime(2025, 1, 1, tzinfo=UTC),
@@ -283,3 +298,106 @@ class TestHtmlToPdfWeasyprint:
         result = _html_to_pdf_weasyprint("<html><body><p>Hello</p></body></html>")
         assert isinstance(result, bytes)
         assert result[:5] == b"%PDF-"
+
+
+class TestRenderDriveFile:
+    """Tests for _render_drive_file."""
+
+    def test_pdf_passthrough(self) -> None:
+        pdf_data = b"%PDF-1.4 drive document"
+        raw = RawReceipt(
+            source_id="drive-1",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=pdf_data,
+            file_content_type="application/pdf",
+        )
+        result = _render_drive_file(raw)
+        assert result == pdf_data
+
+    @patch(
+        "receipt_index.image_converter.image_to_pdf", return_value=b"%PDF-from-image"
+    )
+    def test_image_jpeg_converted(self, mock_convert: MagicMock) -> None:
+        image_data = b"\xff\xd8\xff\xe0fake-jpeg"
+        raw = RawReceipt(
+            source_id="drive-2",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=image_data,
+            file_content_type="image/jpeg",
+        )
+        result = _render_drive_file(raw)
+        assert result == b"%PDF-from-image"
+        mock_convert.assert_called_once_with(image_data)
+
+    @patch("receipt_index.image_converter.image_to_pdf", return_value=b"%PDF-from-png")
+    def test_image_png_converted(self, mock_convert: MagicMock) -> None:
+        image_data = b"\x89PNGfake-png"
+        raw = RawReceipt(
+            source_id="drive-3",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=image_data,
+            file_content_type="image/png",
+        )
+        result = _render_drive_file(raw)
+        assert result == b"%PDF-from-png"
+        mock_convert.assert_called_once_with(image_data)
+
+    def test_raises_without_file_content(self) -> None:
+        raw = RawReceipt(
+            source_id="drive-4",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=None,
+            file_content_type="application/pdf",
+        )
+        with pytest.raises(ValueError, match="no file_content"):
+            _render_drive_file(raw)
+
+    def test_raises_for_unsupported_type(self) -> None:
+        raw = RawReceipt(
+            source_id="drive-5",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=b"data",
+            file_content_type="text/plain",
+        )
+        with pytest.raises(ValueError, match="Unsupported file content type"):
+            _render_drive_file(raw)
+
+
+class TestRenderPdfDriveRouting:
+    """Tests for render_pdf routing to Drive path."""
+
+    def test_gdrive_pdf_routes_to_drive_path(self) -> None:
+        pdf_data = b"%PDF-1.4 drive pdf"
+        raw = RawReceipt(
+            source_id="drive-1",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=pdf_data,
+            file_content_type="application/pdf",
+        )
+        result = render_pdf(raw)
+        assert result == pdf_data
+
+    @patch("receipt_index.image_converter.image_to_pdf", return_value=b"%PDF-converted")
+    def test_gdrive_image_routes_to_drive_path(self, _mock_convert: MagicMock) -> None:
+        raw = RawReceipt(
+            source_id="drive-2",
+            source_name="test-source",
+            source_type="gdrive",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            file_content=b"\xff\xd8\xff\xe0jpeg",
+            file_content_type="image/jpeg",
+        )
+        result = render_pdf(raw)
+        assert result == b"%PDF-converted"

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -19,6 +19,7 @@ _RECEIPT_ROW: dict[str, Any] = {
     "id": UUID("019572a0-0000-7000-8000-000000000001"),
     "source_id": "<msg-1@example.com>",
     "source_type": "imap",
+    "source_name": "test-email",
     "vendor": "Amazon",
     "amount": Decimal("42.99"),
     "currency": "USD",
@@ -29,6 +30,7 @@ _RECEIPT_ROW: dict[str, Any] = {
     "email_subject": "Your Amazon.com order",
     "email_sender": "no-reply@amazon.com",
     "email_date": datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC),
+    "file_name": None,
     "created_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
     "updated_at": datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
 }
@@ -68,7 +70,11 @@ class TestGetProcessedSourceIds:
     def test_executes_correct_sql(self) -> None:
         conn = _mock_conn([])
         get_processed_source_ids(conn)
-        conn.execute.assert_called_once_with("SELECT source_id FROM receipt.receipts")
+        conn.execute.assert_called_once_with(
+            "SELECT source_id FROM receipt.receipts "
+            "UNION "
+            "SELECT source_id FROM receipt.ingest_log"
+        )
 
 
 class TestInsertReceipt:
@@ -80,6 +86,7 @@ class TestInsertReceipt:
             conn,
             source_id="<msg-1@example.com>",
             source_type="imap",
+            source_name="test-email",
             vendor="Amazon",
             amount=Decimal("42.99"),
             currency="USD",
@@ -101,6 +108,7 @@ class TestInsertReceipt:
             conn,
             source_id="<msg-1@example.com>",
             source_type="imap",
+            source_name="test-email",
             vendor="Amazon",
             amount=Decimal("42.99"),
             currency="USD",
@@ -120,6 +128,7 @@ class TestInsertReceipt:
             conn,
             source_id="<msg-1@example.com>",
             source_type="imap",
+            source_name="test-email",
             vendor="Amazon",
             amount=Decimal("42.99"),
             currency="USD",

--- a/uv.lock
+++ b/uv.lock
@@ -1215,6 +1215,38 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/586ec94553b569080caef635f98a3723db36a38eac0e3d7eb3ea9d2e4b9a/google_api_core-2.30.0.tar.gz", hash = "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b", size = 176959 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf06d7ac17d196594e66989299374bfb0d4331d1038e76b/google_api_core-2.30.0-py3-none-any.whl", hash = "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5", size = 173288 },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.193.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/f4/e14b6815d3b1885328dd209676a3a4c704882743ac94e18ef0093894f5c8/google_api_python_client-2.193.0.tar.gz", hash = "sha256:8f88d16e89d11341e0a8b199cafde0fb7e6b44260dffb88d451577cbd1bb5d33", size = 14281006 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6d/fe75167797790a56d17799b75e1129bb93f7ff061efc7b36e9731bd4be2b/google_api_python_client-2.193.0-py3-none-any.whl", hash = "sha256:c42aa324b822109901cfecab5dc4fc3915d35a7b376835233c916c70610322db", size = 14856490 },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1231,6 +1263,32 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", size = 11134 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", size = 9529 },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b4/1b19567e4c567b796f5c593d89895f3cfae5a38e04f27c6af87618fd0942/google_auth_oauthlib-1.3.0.tar.gz", hash = "sha256:cd39e807ac7229d6b8b9c1e297321d36fcc8a9e4857dff4301870985df51a528", size = 21777 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/56/909fd5632226d3fba31d7aeffd4754410735d49362f5809956fe3e9af344/google_auth_oauthlib-1.3.0-py3-none-any.whl", hash = "sha256:386b3fb85cf4a5b819c6ad23e3128d975216b4cac76324de1d90b128aaf38f29", size = 19308 },
 ]
 
 [[package]]
@@ -1467,6 +1525,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099 },
 ]
 
 [[package]]
@@ -2269,6 +2339,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065 },
+]
+
+[[package]]
 name = "openai"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2806,6 +2885,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259 },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428 },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305 },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/79/ac273cbbf744691821a9cca88957257f41afe271637794975ca090b9588b/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc", size = 50480 },
 ]
 
 [[package]]
@@ -3547,13 +3638,18 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
     { name = "pdfplumber" },
+    { name = "pillow" },
     { name = "playwright" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "python-dotenv" },
     { name = "python-slugify" },
+    { name = "pyyaml" },
     { name = "weasyprint" },
 ]
 
@@ -3572,8 +3668,12 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "google-api-python-client", specifier = ">=2.0" },
+    { name = "google-auth", specifier = ">=2.0" },
+    { name = "google-auth-oauthlib", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "pdfplumber", specifier = ">=0.10" },
+    { name = "pillow", specifier = ">=10.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "playwright", specifier = ">=1.40" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
@@ -3584,6 +3684,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "python-slugify", specifier = ">=8.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "weasyprint", specifier = ">=62.0" },
 ]
@@ -3731,6 +3832,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
 ]
 
 [[package]]
@@ -4271,6 +4385,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521 },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Full Phase 2 implementation: YAML config system, Google Drive adapter, multi-source ingestion, and DLQ.

### Config system
- YAML-based source definitions with `${VAR_NAME}` env var interpolation for secrets
- Config file discovery: `--config` flag → `RECEIPT_INDEX_CONFIG` env → `./receipt-index.yaml` → `~/.config/receipt-index/config.yaml`
- Clean break from Phase 1 env var config (ADR-0006)
- `python-dotenv` auto-loads `.env` in CLI

### Google Drive adapter
- `GdriveAdapter` with Drive API file listing, download, pagination, MIME handling (PDF, JPEG, PNG, Google Docs export)
- OAuth2 auth flow via `receipt-index auth gdrive --client-credentials PATH`
- Image-to-PDF conversion via Pillow
- Vision-based metadata extraction for scanned receipts
- Document system prompt recognizes payment confirmations (Zelle, Venmo, PayPal)

### Pipeline improvements
- Source-aware models (`RawReceipt`, `Receipt` with `source_name`, `file_name`)
- Multi-source ingestion with `--source` CLI filter
- Confidence-based skip (`< 0.5`) logged to `ingest_log` as DLQ
- `amount >= 0` (valid for prepaid postage, $0 receipts)
- Transaction rollback before failure log writes (fixes broken error handling)
- Idempotency checks both `receipts` and `ingest_log` tables (skipped/failed items not retried)

### Infrastructure
- Auto-download golang-migrate to `.bin/` — no manual install needed
- Makefile loads `.env` automatically for `make migrate-up` etc.
- `make setup` scaffolds `.env` and `receipt-index.yaml` from examples if missing
- `make check` runs lint + format-check + typecheck + unit tests
- `docker-db-up/down` renamed to `docker-up/down` (starts GreenMail too)
- Updated getting-started and production-setup docs

### DB migrations
- `000005`: Add `source_name` (NOT NULL after backfill with `'legacy-imap'`) and `file_name` columns
- `000006`: Relax amount constraint from `> 0` to `>= 0`

### Test coverage
- 249 unit tests passing, 94% coverage
- Integration tests for multi-source config, Drive adapter, migration up/down
- New test suites: `test_auth.py`, `test_config_loading.py`, `test_gdrive_adapter.py`, `test_image_converter.py`, `test_phase2.py`

### Devtest results (live)
- 1,014 legacy IMAP receipts preserved and searchable
- 4 new IMAP receipts ingested via config
- 459 Google Drive receipts ingested (470 files, 98% success rate)
- 9 correctly skipped as non-receipts, 2 failed (MPO format, oversized image)

## Issues

Closes #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30
Closes #16
Part of #19