### PR TITLE
fix: extract image attachments from email receipts via vision

### DIFF
--- a/src/receipt_index/extraction.py
+++ b/src/receipt_index/extraction.py
@@ -84,7 +84,7 @@ def _to_extraction_result(result: Any) -> ExtractionResult:
     )
 
 
-_IMAGE_CONTENT_TYPES = frozenset({"image/jpeg", "image/png"})
+_IMAGE_CONTENT_TYPES = frozenset({"image/jpeg", "image/png", "image/gif", "image/webp"})
 
 
 def create_extraction_agent(
@@ -167,7 +167,7 @@ def _extract_from_document(
     if raw.file_content is None:
         raise ValueError("Drive-sourced receipt has no file_content")
 
-    content_type = (raw.file_content_type or "").lower()
+    content_type = _base_content_type(raw.file_content_type or "")
 
     if content_type == "application/pdf":
         return _extract_from_pdf_document(raw.file_content, agent=agent)

--- a/src/receipt_index/extraction.py
+++ b/src/receipt_index/extraction.py
@@ -33,6 +33,14 @@ If PDF attachment content is provided below the email body, use it as additional
 context for extraction. The PDF content often contains the detailed receipt with \
 amounts and line items that may not appear in the email body.
 
+If image attachments are provided, they are likely a screenshot or photo of the \
+receipt itself (the email body may be empty) — extract the receipt details from \
+the image.
+
+Payment confirmations (Zelle, Venmo, PayPal, bank transfers, wire transfers) are \
+valid receipts; the vendor is the payment recipient. Use high confidence when the \
+amount, recipient, and date are clearly visible.
+
 Handle forwarded receipts by looking at the original receipt content. \
 For multi-item orders, use the total amount. If the currency is not stated, \
 assume USD.\
@@ -123,7 +131,22 @@ def _extract_from_email(
 
     pdf_text = _extract_pdf_text(raw.attachments)
     prompt = _build_prompt(raw, pdf_text=pdf_text)
-    result: Any = agent.run_sync(prompt)
+
+    images = _image_attachments(raw.attachments)
+    if images:
+        # Send image attachments (e.g. screenshot receipts) to vision alongside
+        # the email text context. The IMAP body is often empty for these.
+        message: list[Any] = [prompt]
+        for att in images:
+            message.append(
+                BinaryContent(
+                    data=att.data,
+                    media_type=_base_content_type(att.content_type),
+                )
+            )
+        result: Any = agent.run_sync(message)
+    else:
+        result = agent.run_sync(prompt)
     return _to_extraction_result(result)
 
 
@@ -243,10 +266,24 @@ def _extract_pdf_text(attachments: list[Attachment]) -> str | None:
     from receipt_index.pdf_reader import extract_text
 
     for att in attachments:
-        if att.content_type.lower() == "application/pdf":
+        if _base_content_type(att.content_type) == "application/pdf":
             text = extract_text(att.data)
             return text if text else None
     return None
+
+
+def _base_content_type(content_type: str) -> str:
+    """Normalize a MIME type to its lowercase base (no parameters)."""
+    return content_type.split(";")[0].strip().lower()
+
+
+def _image_attachments(attachments: list[Attachment]) -> list[Attachment]:
+    """Return attachments whose content type is a supported image."""
+    return [
+        att
+        for att in attachments
+        if _base_content_type(att.content_type) in _IMAGE_CONTENT_TYPES
+    ]
 
 
 def _strip_html_tags(html: str) -> str:

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic_ai import BinaryContent
 
 from receipt_index.extraction import (
     _build_prompt,
@@ -470,3 +471,94 @@ class TestExtractFromDocument:
 
         call_args = agent.run_sync.call_args[0][0]
         assert isinstance(call_args, list)
+
+
+class TestEmailImageAttachments:
+    """Tests for image-attachment handling in the email extraction path."""
+
+    def _mock_agent(self) -> MagicMock:
+        mock_result = _mock_agent_result(
+            ReceiptMetadata(
+                vendor="Dan Ming",
+                amount=Decimal("3500.00"),
+                date=date(2026, 6, 6),
+                confidence=0.95,
+            )
+        )
+        agent = MagicMock()
+        agent.run_sync.return_value = mock_result
+        return agent
+
+    def _raw(self, attachments: list[Attachment]) -> RawReceipt:
+        return RawReceipt(
+            source_id="msg-1",
+            source_name="personal-email",
+            source_type="imap",
+            date=datetime(2026, 6, 6, tzinfo=UTC),
+            subject="Screenshot 2026-06-06 at 12.02.34 PM",
+            sender="rod@morison.io",
+            attachments=attachments,
+        )
+
+    def test_image_attachment_sent_to_vision(self) -> None:
+        raw = self._raw(
+            [Attachment(filename="shot.png", content_type="image/png", data=b"\x89PNG")]
+        )
+        agent = self._mock_agent()
+        result = extract_metadata(raw, agent=agent)
+
+        assert result.metadata.vendor == "Dan Ming"
+        # Image present → message is a list with the text prompt plus binary image
+        message = agent.run_sync.call_args[0][0]
+        assert isinstance(message, list)
+        assert isinstance(message[0], str)
+        assert "Subject: Screenshot" in message[0]
+        binaries = [m for m in message if isinstance(m, BinaryContent)]
+        assert len(binaries) == 1
+        assert binaries[0].media_type == "image/png"
+
+    def test_content_type_with_params_is_normalized(self) -> None:
+        raw = self._raw(
+            [
+                Attachment(
+                    filename="s.png", content_type="image/PNG; name=s.png", data=b"x"
+                )
+            ]
+        )
+        agent = self._mock_agent()
+        extract_metadata(raw, agent=agent)
+
+        message = agent.run_sync.call_args[0][0]
+        binaries = [m for m in message if isinstance(m, BinaryContent)]
+        assert len(binaries) == 1
+        assert binaries[0].media_type == "image/png"
+
+    def test_multiple_images_all_sent(self) -> None:
+        raw = self._raw(
+            [
+                Attachment(filename="a.png", content_type="image/png", data=b"a"),
+                Attachment(filename="b.jpg", content_type="image/jpeg", data=b"b"),
+            ]
+        )
+        agent = self._mock_agent()
+        extract_metadata(raw, agent=agent)
+
+        message = agent.run_sync.call_args[0][0]
+        binaries = [m for m in message if isinstance(m, BinaryContent)]
+        assert len(binaries) == 2
+
+    def test_no_image_attachments_sends_string(self) -> None:
+        raw = RawReceipt(
+            source_id="msg-2",
+            source_name="personal-email",
+            source_type="imap",
+            date=datetime(2026, 6, 6, tzinfo=UTC),
+            subject="Receipt",
+            sender="shop@example.com",
+            text_body="Total: $10.00",
+        )
+        agent = self._mock_agent()
+        extract_metadata(raw, agent=agent)
+
+        message = agent.run_sync.call_args[0][0]
+        assert isinstance(message, str)

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -534,10 +534,13 @@ class TestEmailImageAttachments:
         assert binaries[0].media_type == "image/png"
 
     def test_multiple_images_all_sent(self) -> None:
+        # Also exercises gif/webp support beyond png/jpeg.
         raw = self._raw(
             [
                 Attachment(filename="a.png", content_type="image/png", data=b"a"),
                 Attachment(filename="b.jpg", content_type="image/jpeg", data=b"b"),
+                Attachment(filename="c.gif", content_type="image/gif", data=b"c"),
+                Attachment(filename="d.webp", content_type="image/webp", data=b"d"),
             ]
         )
         agent = self._mock_agent()
@@ -545,7 +548,31 @@ class TestEmailImageAttachments:
 
         message = agent.run_sync.call_args[0][0]
         binaries = [m for m in message if isinstance(m, BinaryContent)]
-        assert len(binaries) == 2
+        assert len(binaries) == 4
+
+    @patch(
+        "receipt_index.pdf_reader.extract_text",
+        return_value="Vendor: Shop Total: $25",
+    )
+    def test_pdf_and_image_combined(self, _mock_extract: MagicMock) -> None:
+        raw = self._raw(
+            [
+                Attachment(
+                    filename="r.pdf", content_type="application/pdf", data=b"%PDF"
+                ),
+                Attachment(filename="s.png", content_type="image/png", data=b"\x89PNG"),
+            ]
+        )
+        agent = self._mock_agent()
+        extract_metadata(raw, agent=agent)
+
+        message = agent.run_sync.call_args[0][0]
+        assert isinstance(message, list)
+        # PDF text still rides in the text prompt at message[0]...
+        assert "Vendor: Shop Total: $25" in message[0]
+        # ...and the image is still sent to vision.
+        binaries = [m for m in message if isinstance(m, BinaryContent)]
+        assert len(binaries) == 1
 
     def test_no_image_attachments_sends_string(self) -> None:
         raw = RawReceipt(


### PR DESCRIPTION
## Problem

The IMAP/email extraction path only read text from **PDF** attachments and the email body — **image attachments were captured by the adapter but never sent to the model**. Emailed screenshot receipts (commonly payment confirmations like Zelle / bank transfers) therefore extracted nothing: confidence `0.10`, amount `0`, and got skipped into the `ingest_log` DLQ.

This surfaced when a batch of Dan Ming partial-lease-payment screenshots were emailed in and all silently skipped, while the same kind of screenshots ingested fine from Google Drive (the gdrive path already routes images to vision).

## Fix

- `_extract_from_email` now sends image attachments to vision as `BinaryContent`, alongside the email text context (the body is often empty for screenshot emails).
- Added `_image_attachments()` and `_base_content_type()` (normalizes MIME types like `image/PNG; name=s.png` → `image/png`); hardened `_extract_pdf_text` to use the same normalization.
- Updated the email system prompt to note that (a) image attachments may *be* the receipt, and (b) payment confirmations (Zelle/Venmo/PayPal/bank transfers) are valid receipts — matching the document prompt.

## Tests

New `TestEmailImageAttachments`: single image → vision, MIME-with-params normalization, multiple images all sent, and the no-image string path still used. Full unit suite green (253 passed, 94% coverage); ruff + mypy clean.

## Verification

Reprocessed the previously-DLQ'd screenshots after the fix — all 4 extracted at 0.85–0.95 confidence as the expected partial payments, and the Nov/Dec/Jan part-1 + part-2 halves now reconcile to \$8,266/month.