### PR TITLE
feat: always-on Docker service with Dropbox mirror and nightly backups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,8 +14,11 @@ htmlcov/
 .coverage
 .env
 data/
+deploy/
 docs/
 tests/
 *.md
+# hatchling requires the readme to build the package (pyproject readme field)
+!README.md
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,15 @@ env/
 # Environment and config
 .env
 receipt-index.yaml
+# ...but the server config in deploy/ holds no secrets (only ${VAR} refs) and
+# is version-controlled. The bare pattern above matches at any depth.
+!deploy/example.receipt-index.yaml
 
 # Data
 data/
+
+# Server-side rclone config directory (contains live Dropbox OAuth tokens)
+rclone-config/
 
 # Coverage
 htmlcov/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Key standards applied:
 - Product spec: `docs/product/features/receipt-search-index-spec.md`
 - Technical design: `docs/engineering/designs/receipt-search-index.md`
 - ADRs: `docs/engineering/adr/`
+- Server deployment (production compose): `docs/user/server-deployment.md` + `deploy/`
 
 ## Local Devtest Setup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,32 @@
-FROM python:3.11-slim AS builder
+FROM python:3.11-slim-bookworm AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
+# Two-phase sync: dependencies first (cache-friendly, no project sources yet),
+# then the project itself. hatchling needs README.md to build the package.
 COPY pyproject.toml uv.lock ./
+RUN uv sync --no-dev --frozen --no-install-project
+
+COPY README.md ./
+COPY src/ src/
 RUN uv sync --no-dev --frozen
 
-COPY src/ src/
+FROM python:3.11-slim-bookworm
 
-FROM python:3.11-slim
+# Pinned third-party binaries (linux/amd64 — the deployment target).
+# supercronic: version + sha256 from the upstream GitHub release. Upstream
+#   publishes a SHA1 in the release notes; the sha256 below is of the artifact
+#   whose SHA1 matches that published value.
+#   https://github.com/aptible/supercronic/releases
+# rclone: sha256 from https://downloads.rclone.org/v1.75.0/SHA256SUMS
+#   ARG names carry a PIN_ prefix because rclone parses ANY RCLONE_* env var
+#   as CLI configuration (RCLONE_VERSION=1.75.0 → invalid --version flag).
+ARG SUPERCRONIC_VERSION=v0.2.48
+ARG SUPERCRONIC_SHA256=88c1b66b94c486f972fdd1a4d1f901e3e75ff04f749cddd60c5db573e3a33c6c
+ARG PIN_RCLONE_VERSION=1.75.0
+ARG PIN_RCLONE_SHA256=266598b5c66a42b821571332013cc85a88ffcff8939cf0643861c8d033dd3a4a
 
 RUN groupadd --gid 1000 appuser && \
     useradd --uid 1000 --gid 1000 --create-home appuser
@@ -20,6 +37,56 @@ COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/src /app/src
 
 ENV PATH="/app/.venv/bin:$PATH"
+
+# Browsers live outside the venv so every user (uid 1000 at runtime) can read
+# them; the renderer defaults to a CWD-relative path when this is unset.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# System packages, in one layer:
+#   - weasyprint runtime libs, per the WeasyPrint docs for Debian >= 11
+#     (libpango-1.0-0, libpangoft2-1.0-0, libharfbuzz-subset0) plus fonts for
+#     the plain-text receipt template, which asks for a monospace face
+#   - postgresql-client-18 from PGDG: bookworm ships client v15, too old to
+#     pg_dump the v18 production server (nightly backup job)
+#   - Chromium (headless shell only) and its OS dependencies, installed with
+#     the *venv's* playwright CLI so the browser build always matches the
+#     pinned pip `playwright` version in uv.lock. Bumping that pin REQUIRES
+#     rebuilding this image: Playwright refuses to launch a browser revision
+#     it did not install.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        -o /usr/share/keyrings/pgdg.asc; \
+    echo "deb [signed-by=/usr/share/keyrings/pgdg.asc]" \
+        "https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        fontconfig \
+        fonts-dejavu-core \
+        libharfbuzz-subset0 \
+        libpango-1.0-0 \
+        libpangoft2-1.0-0 \
+        postgresql-client-18; \
+    /app/.venv/bin/playwright install --with-deps --only-shell chromium; \
+    chmod -R a+rX "${PLAYWRIGHT_BROWSERS_PATH}"; \
+    rm -rf /var/lib/apt/lists/*
+
+# Scheduler (supercronic) and Dropbox mirror (rclone) binaries. Both are
+# checksum-verified; a version bump must bring its checksum with it.
+RUN set -eux; \
+    curl -fsSL -o /usr/local/bin/supercronic \
+        "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-amd64"; \
+    echo "${SUPERCRONIC_SHA256}  /usr/local/bin/supercronic" | sha256sum -c -; \
+    chmod 0755 /usr/local/bin/supercronic; \
+    supercronic -version; \
+    curl -fsSL -o /tmp/rclone.deb \
+        "https://downloads.rclone.org/v${PIN_RCLONE_VERSION}/rclone-v${PIN_RCLONE_VERSION}-linux-amd64.deb"; \
+    echo "${PIN_RCLONE_SHA256}  /tmp/rclone.deb" | sha256sum -c -; \
+    dpkg --install /tmp/rclone.deb; \
+    rm -f /tmp/rclone.deb; \
+    rclone version
 
 USER appuser
 

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Nightly database backup, run from deploy/crontab inside the scheduler
+# container. Writes a pg_dump custom-format archive into the bind-mounted
+# /app/data/backups directory using day-of-week rotation, so the directory
+# holds at most 7 files and the rclone mirror of it stays bounded too
+# (`rclone copy` never deletes at the destination, but it does overwrite
+# changed files — a fixed 7-name set is what keeps Dropbox from growing).
+#
+# Why a script instead of an inline crontab command:
+#   * supercronic hands the whole command line to `$SHELL -c` and does NOT
+#     implement classic cron's `%`-means-newline rule, so `date +%u` inline
+#     would in fact work — but relying on that divergence from vixie-cron is
+#     the kind of thing that breaks silently if the scheduler is ever swapped.
+#   * The dump-to-temp-then-rename dance below needs more than one statement.
+#
+# Custom format (-Fc) is deliberate: it is already compressed, and the cutover
+# and disaster-recovery procedures restore with `pg_restore` *without*
+# --no-owner / --no-acl so that ownership lands back on receipt_index.
+#
+# Written to a .tmp name and renamed into place so a concurrent rclone sync
+# tick can never mirror a half-written dump.
+
+set -eu
+
+: "${DATABASE_URL:?DATABASE_URL must be set in the container environment}"
+
+BACKUP_DIR="${BACKUP_DIR:-/app/data/backups}"
+
+mkdir -p "${BACKUP_DIR}"
+
+# 1..7, Monday..Sunday
+dow="$(date +%u)"
+target="${BACKUP_DIR}/receipt_index-${dow}.dump"
+tmp="${target}.tmp"
+
+# A failed dump must not strand a partial .tmp: the mirror is additive-only,
+# so anything it uploads stays on Dropbox forever. Belt (this trap) and
+# suspenders (--exclude "*.tmp" on the crontab mirror line).
+trap 'rm -f "${tmp}"' EXIT
+
+echo "backup: dumping to ${target}"
+
+pg_dump --format=custom --no-password --file="${tmp}" "${DATABASE_URL}"
+mv -f "${tmp}" "${target}"
+
+echo "backup: wrote ${target} ($(wc -c < "${target}") bytes)"

--- a/deploy/crontab
+++ b/deploy/crontab
@@ -1,0 +1,40 @@
+# supercronic crontab for the receipt-index scheduler container.
+#
+# Mounted read-only at /app/crontab; the compose `scheduler` service overrides
+# the image ENTRYPOINT with `supercronic /app/crontab`.
+#
+# Notes:
+#   * supercronic will not start a job while its previous run is still going —
+#     no-overlap is the default, per job line. That is the whole of the
+#     no-overlap guarantee; the application has no locking of its own.
+#     "Falling behind" warnings in the container log mean a cycle outran its
+#     interval — the early-warning signal for issue #36.
+#   * No environment is declared here. supercronic does not scrub the
+#     environment before running jobs, so everything from the compose
+#     `env_file` / `environment` (DATABASE_URL, ANTHROPIC_API_KEY,
+#     RECEIPT_INDEX_CONFIG, ...) is already visible to these commands.
+#   * Job stdout/stderr goes to the container log. `receipt-index ingest` exits
+#     1 when any single item failed; that is a per-cycle signal, not a stuck
+#     state, and supercronic simply schedules the next tick.
+#   * Schedules are in the container's timezone, which is UTC unless TZ is set
+#     in the compose environment. Only the nightly backup line cares.
+#   * Commands run under /bin/sh -c (supercronic's default; it takes no `%`
+#     shortcuts — see deploy/backup.sh).
+#   * The ingest and sync lines are deliberately decoupled: a failed item must
+#     never hold up the Dropbox mirror. Their minute offsets keep them from
+#     routinely colliding, but note that no-overlap is per line — a long ingest
+#     can still run through a sync tick.
+
+# Ingest every 15 minutes.
+*/15 * * * * receipt-index ingest
+
+# Mirror rendered receipts to Dropbox, offset from the ingest boundaries.
+# `copy` is additive: it never deletes at the destination.
+7,22,37,52 * * * * rclone copy /app/data/receipts dropbox:receipt-index/receipts --config /app/.rclone/rclone.conf -v
+
+# Mirror the rotating database dumps. Same additive semantics; the fixed set of
+# 7 day-of-week filenames is what bounds the destination.
+12,27,42,57 * * * * rclone copy /app/data/backups dropbox:receipt-index/backups --exclude "*.tmp" --config /app/.rclone/rclone.conf -v
+
+# Nightly database dump, day-of-week rotation (7 files).
+17 3 * * * /app/backup.sh

--- a/deploy/db-init/01-create-roles.sh
+++ b/deploy/db-init/01-create-roles.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Production role bootstrap for the compose Postgres instance.
+#
+# The official postgres image runs every *.sh and *.sql in
+# /docker-entrypoint-initdb.d exactly once, on first boot of an empty data
+# directory. This is a .sh (not a .sql) so the database name and the
+# application password come from the container environment instead of being
+# hardcoded — the defect that makes db/init/01-create-roles.sql (dev) unusable
+# in production, where it would abort init under ON_ERROR_STOP by granting on a
+# database name that does not exist.
+#
+# Roles created:
+#   receipt_index            LOGIN  — the application role. Owns the database
+#                                     and, after the cutover restore, every
+#                                     object in it. DATABASE_URL connects here.
+#   receipt_index_dev_all    NOLOGIN — grant target of migrations 000002/000004.
+#   receipt_index_dev_write  NOLOGIN — grant target of migrations 000002/000004+.
+#   receipt_index_dev_read   NOLOGIN — grant target of migration 000002+.
+#
+# The three _dev_* roles are NOLOGIN members of nothing; receipt_index is
+# granted membership in each, so it inherits every privilege the migrations
+# hand out. _dev_all in particular is NOT optional: a fresh (non-restored)
+# database cannot pass `make migrate-up` without it, because 000002 and 000004
+# GRANT to that role by name.
+#
+# The "_dev_" naming is a historical artifact of the docker dev setup that the
+# migration files bake in by name. Renaming them is a migration change, not a
+# deployment change.
+
+set -euo pipefail
+
+: "${POSTGRES_DB:?POSTGRES_DB must be set (database name)}"
+: "${POSTGRES_USER:?POSTGRES_USER must be set (superuser name)}"
+: "${RECEIPT_INDEX_PASSWORD:?RECEIPT_INDEX_PASSWORD must be set (password for the receipt_index application role)}"
+
+echo "db-init: creating application roles in database '${POSTGRES_DB}'"
+
+psql \
+    --set ON_ERROR_STOP=1 \
+    --username "${POSTGRES_USER}" \
+    --dbname "${POSTGRES_DB}" \
+    --set app_password="${RECEIPT_INDEX_PASSWORD}" \
+    --set db="${POSTGRES_DB}" \
+    <<'EOSQL'
+-- 1. Application login role. Created without a password, then ALTERed, so the
+--    secret is passed as a psql variable (:'app_password' is quoted as a SQL
+--    literal by psql) rather than interpolated by the shell.
+SELECT 'CREATE ROLE receipt_index LOGIN'
+ WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'receipt_index')
+\gexec
+
+ALTER ROLE receipt_index WITH LOGIN INHERIT PASSWORD :'app_password';
+
+-- 2. Grant-target roles referenced by name in db/migrations/receipt/*.sql.
+--    NOLOGIN: they exist only to carry privileges, which receipt_index
+--    inherits via membership.
+DO $$
+DECLARE
+    target text;
+BEGIN
+    FOREACH target IN ARRAY ARRAY[
+        'receipt_index_dev_all',
+        'receipt_index_dev_write',
+        'receipt_index_dev_read'
+    ] LOOP
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = target) THEN
+            EXECUTE format('CREATE ROLE %I NOLOGIN', target);
+        END IF;
+        EXECUTE format('GRANT %I TO receipt_index', target);
+    END LOOP;
+END $$;
+
+-- 3. Database-level privileges and ownership.
+GRANT CONNECT ON DATABASE :"db" TO receipt_index;
+GRANT CONNECT ON DATABASE :"db" TO receipt_index_dev_all;
+GRANT CONNECT ON DATABASE :"db" TO receipt_index_dev_write;
+GRANT CONNECT ON DATABASE :"db" TO receipt_index_dev_read;
+
+-- receipt_index owns the database so it can create schemas, and so the
+-- cutover restore (run without --no-owner) can reassign ownership to it.
+ALTER DATABASE :"db" OWNER TO receipt_index;
+
+-- PostgreSQL 15+ only: schema `public` is no longer world-writable, so its
+-- ownership must be handed to the application role or the first migration's
+-- DDL fails with "permission denied for schema public".
+ALTER SCHEMA public OWNER TO receipt_index;
+EOSQL
+
+echo "db-init: roles ready (receipt_index owns database '${POSTGRES_DB}')"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,116 @@
+# Production compose project for the always-on receipt-index service.
+#
+# The repo-root docker-compose.yml is the *dev* stack (db + GreenMail) and is
+# untouched by this file. There is no GreenMail here.
+#
+# Run it from the clone root:
+#     docker compose -f deploy/docker-compose.yml up -d
+#
+# Path conventions, because compose resolves relative paths against the
+# directory holding this file (deploy/), not the working directory:
+#   ./  -> deploy/            (config that is version-controlled)
+#   ../ -> the clone root     (secrets and mutable server state, git-ignored)
+#
+# Server state that lives at the clone root: .env, data/receipts,
+# data/backups, rclone-config/. All three data directories must be owned by
+# uid/gid 1000 (the image's appuser) — see docs/user/server-deployment.md.
+
+name: receipt-index
+
+services:
+  db:
+    image: postgres:18
+    restart: unless-stopped
+    # POSTGRES_DB / POSTGRES_USER / POSTGRES_PASSWORD / RECEIPT_INDEX_PASSWORD
+    # come from here. env_file (container environment) is used rather than
+    # ${VAR} interpolation because the .env lives at the clone root, and
+    # compose only auto-loads a .env sitting next to the compose file — so
+    # interpolated values would silently resolve to empty.
+    env_file: ../.env
+    ports:
+      # Loopback only. Enough for `make migrate-up`, psql, and pg_restore on
+      # the server (and from the laptop over an SSH tunnel); not reachable
+      # from the network.
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-15432}:5432"
+    volumes:
+      # PostgreSQL 18 requires the volume at /var/lib/postgresql — NOT the
+      # /var/lib/postgresql/data subdirectory used by earlier majors.
+      # Getting this wrong loses the cluster on the next container restart.
+      - pgdata:/var/lib/postgresql
+      # Runs once, on first boot of an empty volume.
+      - ./db-init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", 'pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging:
+      # Always-on box: container logs share a disk with pgdata and the receipt
+      # store, so they are capped rather than left to grow without bound.
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "7"
+
+  scheduler:
+    build:
+      # Build context is the clone root; `dockerfile` is resolved relative to
+      # the context, so it is a bare filename here, not ../Dockerfile.
+      context: ..
+      dockerfile: Dockerfile
+    image: receipt-index
+    # supercronic replaces the image's ENTRYPOINT ["receipt-index"]. The CLI is
+    # still reachable for ad-hoc use via `docker compose ... exec scheduler
+    # receipt-index <cmd>`.
+    entrypoint: ["supercronic", "/app/crontab"]
+    restart: unless-stopped
+    # Give a mid-cycle ingest time to finish on docker stop / host shutdown:
+    # the 10s default would SIGKILL it mid-item, orphaning a PDF that the
+    # additive Dropbox mirror then preserves forever.
+    stop_grace_period: 5m
+    # PID 1 zombie reaping: Chromium forks aggressively during rendering.
+    init: true
+    # Chromium crashes on the 64 MB default /dev/shm.
+    shm_size: 1gb
+    depends_on:
+      db:
+        condition: service_healthy
+    # Secrets: IMAP_PASSWORD, ANTHROPIC_API_KEY, GDRIVE_TOKEN_JSON,
+    # DATABASE_URL. Never baked into the image. See deploy/example.env.
+    env_file: ../.env
+    environment:
+      # Explicit rather than relying on CWD-relative config discovery, which
+      # breaks under `docker compose exec -w`.
+      RECEIPT_INDEX_CONFIG: /app/receipt-index.yaml
+      # Pinned explicitly because env_file values override baked image ENV: a
+      # stray PLAYWRIGHT_BROWSERS_PATH in ../.env (e.g. the dev .playwright
+      # value) would otherwise silently break Chromium discovery and downgrade
+      # every HTML receipt to the weasyprint fallback. Service-level
+      # environment: beats env_file, making that leak mechanically impossible.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+    volumes:
+      # Rendered receipt tree. Bind-mounted (not a named volume) so it can be
+      # rsynced in at cutover and read by rclone from the host if needed.
+      - ../data/receipts:/app/data/receipts
+      # Nightly pg_dump output, mirrored to Dropbox by the sync cron line.
+      - ../data/backups:/app/data/backups
+      # Copied from deploy/example.receipt-index.yaml at provision time and
+      # edited with your sources; the copy is gitignored.
+      - ./receipt-index.yaml:/app/receipt-index.yaml:ro
+      - ./crontab:/app/crontab:ro
+      - ./backup.sh:/app/backup.sh:ro
+      # rclone's config directory, mounted READ-WRITE and as a whole directory.
+      # Dropbox access tokens are short-lived; on refresh rclone rewrites
+      # rclone.conf by creating a temp file and renaming it over the original.
+      # A :ro mount or a single-file bind mount breaks that rename and the
+      # mirror dies silently a few hours after deploy. See rclone-setup.md.
+      - ../rclone-config:/app/.rclone
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "7"
+
+volumes:
+  pgdata:

--- a/deploy/example.env
+++ b/deploy/example.env
@@ -1,0 +1,113 @@
+# Server environment template for the always-on deployment.
+#
+# Copy to the CLONE ROOT as `.env` (not into deploy/) — that is where
+# deploy/docker-compose.yml's `env_file: ../.env` and the Makefile both look:
+#
+#     cp deploy/example.env .env && chmod 600 .env
+#
+# Real values come from 1Password. Nothing in this file is a real secret and
+# nothing real is ever committed — `.env` is git-ignored.
+#
+# Two consumers, one file:
+#   * containers   — every variable below is injected into both compose
+#                    services as container environment.
+#   * the Makefile — auto-exports .env, so `make migrate-up` on the server
+#                    picks up MIGRATION_DATABASE_URL from here.
+#
+# ---------------------------------------------------------------------------
+# READ THIS BEFORE PASTING A PASSWORD CONTAINING `$`
+# ---------------------------------------------------------------------------
+# Docker Compose expands `$VAR` inside env_file values. A password of
+# `ab$wcd` is delivered to the container as `ab` — compose substitutes the
+# (undefined) variable `wcd` with an empty string and only logs
+# `The "wcd" variable is not set` on stderr. Authentication then fails with a
+# message that says nothing about the real cause.
+#
+# Escape every literal dollar sign by doubling it:  ab$wcd  ->  ab$$wcd
+# This applies to IMAP_PASSWORD, ANTHROPIC_API_KEY, both POSTGRES passwords,
+# and the passwords embedded in DATABASE_URL / MIGRATION_DATABASE_URL.
+# `make` (which also reads this file) has the same hazard with `$`.
+#
+# The simpler option: generate the Postgres passwords from an alphanumeric
+# alphabet so the question never comes up — e.g. `openssl rand -hex 24`.
+# Verify after editing: the command below must print no "variable is not set"
+# warnings.
+#
+#     docker compose -f deploy/docker-compose.yml config --quiet
+
+# ---------------------------------------------------------------------------
+# PostgreSQL — the `db` service
+# ---------------------------------------------------------------------------
+
+# Superuser created by the postgres image on first boot. Used for migrations
+# and for the cutover pg_restore; the application never connects as this role.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=replace-with-superuser-password  # pragma: allowlist secret
+POSTGRES_DB=receipt_index
+
+# Password for the `receipt_index` application role, created by
+# deploy/db-init/01-create-roles.sh on first boot. Must match the password in
+# DATABASE_URL below. Changing it later requires an ALTER ROLE — the init
+# script only runs once, against an empty data directory.
+RECEIPT_INDEX_PASSWORD=replace-with-app-role-password  # pragma: allowlist secret
+
+# ---------------------------------------------------------------------------
+# Database URLs
+# ---------------------------------------------------------------------------
+
+# Application connection, used inside the containers. Host `db` is the
+# compose-internal service name on the default network — port 5432, not the
+# published host port. Role `receipt_index` owns the database and every object
+# in it, which is the privilege model the cutover dump restores into.
+DATABASE_URL=postgresql://receipt_index:replace-with-app-role-password@db:5432/receipt_index  # pragma: allowlist secret
+
+# Migrations, run from the HOST with `make migrate-up`. Points at the
+# loopback-published port, so it uses 127.0.0.1 and the host port below.
+#
+# Runs as `receipt_index` (the database/schema owner), NOT the superuser, so
+# every object created by a migration is owned by the app role — the same
+# ownership model the cutover restore produces. pg_trgm is a trusted extension
+# (PG 13+), so the owner can CREATE EXTENSION without superuser.
+#
+# MUST already contain a `?` query parameter: the Makefile appends
+# `&x-migrations-table=...` to this string, and without an existing `?` the
+# resulting URL is malformed and golang-migrate fails to connect.
+MIGRATION_DATABASE_URL=postgresql://receipt_index:replace-with-app-role-password@127.0.0.1:15432/receipt_index?sslmode=disable  # pragma: allowlist secret
+
+# Host port for the loopback-only publish of Postgres. NOTE: this one is read
+# by compose *interpolation*, which does not see this file (compose only
+# auto-loads a .env sitting beside the compose file). Leave it at the default
+# or pass `--env-file .env` on the compose command line; the compose file
+# defaults to 15432 when unset. Keep it in sync with MIGRATION_DATABASE_URL.
+POSTGRES_HOST_PORT=15432
+
+# ---------------------------------------------------------------------------
+# Application secrets — interpolated into deploy/receipt-index.yaml
+# ---------------------------------------------------------------------------
+
+# 1Password item for your IMAP mailbox app password
+IMAP_PASSWORD=replace-with-imap-app-password  # pragma: allowlist secret
+
+# Vault item (Personal) — Anthropic receipt-index api key
+ANTHROPIC_API_KEY=sk-ant-replace-me  # pragma: allowlist secret
+
+# Google Drive OAuth token, produced by:
+#     receipt-index auth gdrive --client-credentials <client_secret.json>
+# Single line of JSON. It carries client_id/client_secret alongside the refresh
+# token, which is why GDRIVE_CREDENTIALS_JSON is not needed on the server —
+# deploy/receipt-index.yaml drops that key (the repo-root config still has it).
+GDRIVE_TOKEN_JSON={"token":"...","refresh_token":"...","client_id":"...","client_secret":"..."}  # pragma: allowlist secret
+
+# ---------------------------------------------------------------------------
+# Do NOT set these on the server
+# ---------------------------------------------------------------------------
+#
+# PLAYWRIGHT_BROWSERS_PATH — the image bakes /ms-playwright. The dev value
+#   (.playwright) is a relative path that does not exist in the container; if
+#   it leaks into this file every HTML receipt fails to render and is
+#   permanently dead-lettered. Do not copy it over from the repo-root
+#   example.env.
+#
+# RECEIPT_INDEX_CONFIG — set explicitly in deploy/docker-compose.yml.
+#
+# GREENMAIL_* — dev-only; there is no GreenMail in the production stack.

--- a/deploy/example.receipt-index.yaml
+++ b/deploy/example.receipt-index.yaml
@@ -1,0 +1,48 @@
+# Server application config TEMPLATE. Copy to deploy/receipt-index.yaml
+# (gitignored) and fill in your source definitions; the copy is mounted
+# read-only at /app/receipt-index.yaml via RECEIPT_INDEX_CONFIG in
+# deploy/docker-compose.yml.
+#
+# Mirrors the source definitions of the repo-root receipt-index.yaml. Two
+# deliberate differences:
+#
+#   1. store.path is the absolute in-container bind-mount path. The dev config
+#      uses ./data/receipts, which resolves against the CWD — fragile under
+#      `docker compose exec -w`.
+#   2. The gdrive source drops `credentials_json`. GdriveSourceConfig has no
+#      such field (it is ignored on parse), but ${VAR} interpolation happens
+#      *before* parsing and hard-fails on undefined names — so keeping the key
+#      would force GDRIVE_CREDENTIALS_JSON into the server .env purely to
+#      satisfy a value nothing reads. The OAuth client id/secret needed for
+#      token refresh are already inside GDRIVE_TOKEN_JSON.
+#
+# Every ${VAR} below must be defined in the clone-root .env — see
+# deploy/example.env. A missing one aborts startup with the full list.
+
+sources:
+  - name: personal-email
+    type: imap
+    host: mail.example.com
+    port: 993
+    username: user@example.com
+    password: ${IMAP_PASSWORD}
+    folder: INBOX.Receipts
+    use_ssl: true
+
+  - name: scanned-receipts
+    type: gdrive
+    folder_id: "replace-with-gdrive-folder-id"
+    token_json: ${GDRIVE_TOKEN_JSON}
+
+database:
+  url: ${DATABASE_URL}
+
+store:
+  path: /app/data/receipts
+
+llm:
+  model: claude-haiku-4-5-20251001
+  api_key: ${ANTHROPIC_API_KEY}
+
+logging:
+  level: INFO

--- a/deploy/rclone-setup.md
+++ b/deploy/rclone-setup.md
@@ -1,0 +1,115 @@
+# rclone Dropbox setup (one-time)
+
+Produces the `rclone-config/` directory that `deploy/docker-compose.yml` mounts
+into the scheduler container. OAuth needs a browser, so the authorization runs
+on the laptop and the resulting config is copied to the server.
+
+Do this once, before the first Dropbox mirror.
+
+## 1. Create a dedicated Dropbox app
+
+rclone ships a shared client ID that is heavily rate-limited (`too_many_requests`
+during a bulk mirror). Use your own.
+
+At <https://www.dropbox.com/developers/apps> → **Create app**:
+
+- [ ] API: **Scoped access**
+- [ ] Access type: **App folder** (isolates it to `Apps/<app name>/`) or **Full
+      Dropbox** — either works; App folder is the tighter choice
+- [ ] Name it something identifiable, e.g. `receipt-index-mirror`
+
+Then, **before authorizing anything**, on the app's **Permissions** tab enable:
+
+- [ ] `account_info.read`
+- [ ] `files.metadata.write`
+- [ ] `files.content.write`
+- [ ] `files.content.read`
+- [ ] Click **Submit**
+
+> Scopes are frozen into the token at authorize time. Enabling a scope after
+> the fact does nothing until you re-run the authorization — the symptom is a
+> `missing_scope` error at the first upload, not at setup.
+
+On the **Settings** tab:
+
+- [ ] Add OAuth 2 redirect URI: `http://localhost:53682/`
+- [ ] Copy the **App key** and **App secret**
+
+## 2. Authorize on the laptop
+
+```bash
+rclone config
+```
+
+- [ ] `n` — new remote
+- [ ] name: `dropbox`  (must match the `dropbox:` prefix in `deploy/crontab`)
+- [ ] storage: `dropbox`
+- [ ] `client_id`: the App key from step 1
+- [ ] `client_secret`: the App secret from step 1
+- [ ] advanced config: `n`
+- [ ] use auto config: `y` — opens a browser, redirects to `localhost:53682`
+- [ ] confirm, then `q` to quit
+
+Verify:
+
+```bash
+rclone lsd dropbox:
+rclone mkdir dropbox:receipt-index/receipts
+rclone mkdir dropbox:receipt-index/backups
+```
+
+## 3. Copy the config directory to the server
+
+Copy the whole directory, not just `rclone.conf` (see step 4).
+
+```bash
+rclone config file          # prints the path, usually ~/.config/rclone/rclone.conf
+scp -r ~/.config/rclone/ receipt-server:/path/to/receipt-index/rclone-config
+```
+
+On the server, in the clone root:
+
+```bash
+sudo chown -R 1000:1000 rclone-config
+chmod 700 rclone-config
+chmod 600 rclone-config/rclone.conf
+```
+
+uid/gid 1000 is the image's `appuser`. `rclone-config/` is git-ignored.
+
+## 4. Why the mount is read-write
+
+`deploy/docker-compose.yml` mounts `../rclone-config:/app/.rclone` with **no
+`:ro`**, and mounts the **directory**, never `rclone.conf` alone. Both are
+load-bearing:
+
+Dropbox access tokens expire after about four hours. On refresh, rclone
+rewrites its config by writing a sibling temp file and `rename()`-ing it over
+`rclone.conf`. A read-only mount fails the write; a single-file bind mount
+pins the inode so the rename cannot replace it. Either way the container keeps
+the stale token, and the mirror stops working a few hours after a deploy that
+looked fine — with the only symptom buried in the container log.
+
+## 5. Verify from inside the container
+
+```bash
+docker compose -f deploy/docker-compose.yml exec scheduler \
+    rclone lsd dropbox: --config /app/.rclone/rclone.conf
+```
+
+This must succeed **as uid 1000** — it proves both the ownership and the
+credentials, which an `ls` on the host does not.
+
+Leave the sync cron lines disabled until the initial bulk mirror has been run
+manually and file counts match. `rclone copy` is additive and never deletes, so
+a bad first mirror does not self-clean:
+
+```bash
+docker compose -f deploy/docker-compose.yml exec scheduler \
+    rclone copy /app/data/receipts dropbox:receipt-index/receipts \
+    --config /app/.rclone/rclone.conf -v
+
+# counts must match
+find data/receipts -type f | wc -l
+rclone size dropbox:receipt-index/receipts
+```

--- a/docs/brainstorms/2026-08-01-always-on-service-requirements.md
+++ b/docs/brainstorms/2026-08-01-always-on-service-requirements.md
@@ -1,0 +1,105 @@
+---
+date: 2026-08-01
+topic: always-on-service
+---
+
+# Always-On Receipt Service
+
+## Problem Frame
+
+Receipt ingestion today is a manual, laptop-bound CLI run. New receipts (email, GDrive uploads) sit unprocessed until the operator runs `receipt-index ingest`, and the `data/receipts` PDF store lives only on the dev machine. Move the pipeline to a home Ubuntu server as an unattended Docker service: poll sources on a schedule, process new receipts within ~15–30 minutes of arrival, and mirror `data/receipts` to Dropbox for off-machine access and backup. This is a deployment/operations change — no new application features.
+
+---
+
+## Key Flows
+
+- F1. Scheduled ingest
+  - **Trigger:** Scheduler fires every 15 minutes (configurable).
+  - **Steps:** Run existing `receipt-index ingest` against all configured sources → new items extracted, rendered, indexed; skips/failures land in `ingest_log` DLQ as today → run summary logged.
+  - **Outcome:** New receipts searchable and stored under `data/receipts` without human action.
+  - **Covered by:** R2, R3, R9
+
+- F2. Dropbox mirror
+  - **Trigger:** After each ingest cycle (or on its own short interval).
+  - **Steps:** rclone additively copies `data/receipts` to a dedicated Dropbox folder.
+  - **Outcome:** Every rendered receipt PDF is visible in Dropbox within minutes; server remains source of truth.
+  - **Covered by:** R4
+
+- F3. Search from laptop
+  - **Trigger:** The operator needs a receipt during reconciliation.
+  - **Steps:** SSH wrapper runs `receipt-index search`/`show`/`failures` inside the server container; receipt PDFs open from the Dropbox mirror.
+  - **Outcome:** Full search workflow without the laptop hosting any service state.
+  - **Covered by:** R7
+
+---
+
+## Requirements
+
+**Service & scheduling**
+- R1. All components run as a single docker compose project on the server; `docker compose up -d` brings up the full service and it survives server reboots (restart policies + Docker enabled at boot).
+- R2. Ingest is the existing one-shot CLI run by a scheduler container every 15 minutes (interval configurable); no new daemon code in the application.
+- R3. Ingest runs never overlap — if a cycle is still running, the next tick is skipped.
+
+**Dropbox sync**
+- R4. `data/receipts` is mirrored one-way (server → Dropbox) via rclone, additive copy only: deletions/renames on the server are never propagated as deletions in Dropbox. Sync provider is an rclone remote config detail, not application code.
+
+**Database & search access**
+- R5. Postgres 18 runs in the compose project with a persistent volume; existing production data (currently native pg on the dev machine, port 5435) is migrated once at cutover via dump/restore.
+- R6. Schema migrations (golang-migrate, both migration tables) are applied as an explicit deploy step against the server DB.
+- R7. Search/show/failures remain available from the laptop via an SSH wrapper into the running container; no web UI in this phase.
+
+**Operations**
+- R8. Secrets (IMAP, Anthropic key, GDrive token, DB password) live in a server-side `.env` provisioned from 1Password; never baked into the image or committed. rclone's Dropbox token lives in a server-side rclone config file, generated once via interactive OAuth on the laptop.
+- R9. Each ingest cycle logs a one-line summary (counts: processed / skipped / failed); DLQ remains inspectable via `receipt-index failures`; container logs are the single place to look (`docker compose logs`).
+
+---
+
+## Success Criteria
+
+- A receipt emailed or dropped in the GDrive source folder appears in search results and in the Dropbox mirror within ~30 minutes, with no laptop involvement.
+- The server can be rebooted and the service resumes unattended.
+- `ce-plan` can produce a deploy plan directly from this doc without inventing product behavior — only technical choices (scheduler image, rclone invocation details, image distribution) remain.
+
+---
+
+## Scope Boundaries
+
+- No new ingestion trigger mechanisms (IMAP IDLE push, GDrive webhooks) — polling only.
+- No web UI, API, or remote search endpoint — SSH access is sufficient.
+- No bidirectional Dropbox sync; Dropbox is a read-only mirror, not an ingest source (a `dropbox` source type is a possible future compounding step, not this phase).
+- No CI/CD or registry-based image delivery required for v1 — building on the server from a git clone is acceptable.
+- Issue #36 (O(N) IMAP enumeration) is not solved here; it bounds how cheap frequent polling is, not whether this works.
+
+---
+
+## Key Decisions
+
+- Poll, don't push: 15–30 min latency confirmed acceptable; existing one-shot CLI reused verbatim.
+- Scheduler-in-compose over host cron: keeps the entire deployment declarative in the repo; nothing to configure on the host beyond Docker + the `.env`/rclone config.
+- Dropbox via rclone sidecar: provider becomes swappable config; additive copy protects against accidental deletion cascades.
+- Database moves to the server: the service owns its data; the dev-machine pg 5435 instance is retired for this project after cutover.
+
+---
+
+## Dependencies / Assumptions
+
+- The server has (or will get) Docker Engine + compose plugin and outbound HTTPS/IMAPS access.
+- GDrive OAuth token refresh continues to work headlessly once provisioned (existing `receipt-index auth gdrive` flow).
+- Anthropic API spend at 96 polls/day is dominated by new-receipt extraction, not polling itself (polling costs no LLM calls; IMAP/GDrive enumeration is the only per-poll cost).
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2][Technical] Scheduler container choice (supercronic vs ofelia vs loop-wrapper) and how R3's no-overlap guarantee is enforced.
+- [Affects R4][Technical] rclone cadence and coupling (post-ingest hook vs independent timer) and Dropbox destination folder naming.
+- [Affects R5][Technical] Whether to expose Postgres on a host port for ad-hoc laptop `psql`, or keep it compose-internal only.
+- [Affects R9][Technical] Tame pdfminer/fontTools DEBUG noise in the CLI entrypoint (existing open issue) so container logs stay readable.
+
+---
+
+## Next Steps
+
+-> `/ce-plan` for structured implementation planning

--- a/docs/plans/2026-08-01-001-feat-always-on-docker-service-plan.md
+++ b/docs/plans/2026-08-01-001-feat-always-on-docker-service-plan.md
@@ -1,0 +1,389 @@
+---
+title: "feat: Always-on Docker service with Dropbox mirror"
+type: feat
+status: completed
+date: 2026-08-01
+origin: docs/brainstorms/2026-08-01-always-on-service-requirements.md
+deepened: 2026-08-01
+---
+
+# feat: Always-on Docker service with Dropbox mirror
+
+## Overview
+
+Move receipt ingestion from a manual, laptop-bound CLI run to an unattended Docker compose deployment on a home server: Postgres 18 in compose, a supercronic-scheduled `receipt-index ingest` every 15 minutes with a no-overlap guarantee, and an rclone additive copy of `data/receipts` to Dropbox. No new application features — two small app-code changes (library log levels, render-time network egress blocking), image hardening, compose/scheduler wiring, and a documented cutover.
+
+---
+
+## Problem Frame
+
+New receipts sit unprocessed until the operator runs `receipt-index ingest` on the dev machine, and the PDF store exists only there (see origin: docs/brainstorms/2026-08-01-always-on-service-requirements.md). The service must process receipts within ~15–30 minutes unattended, survive reboots, and mirror receipts to Dropbox for off-machine access.
+
+**Critical constraint discovered in research:** the existing production `Dockerfile` installs neither Playwright browsers nor weasyprint's system libraries, so every HTML/text email receipt would fail rendering in-container. Because failures land in `ingest_log` (DLQ) and are then *permanently skipped* by idempotency, deploying the current image would silently lose receipts. Image hardening (U1) is therefore a hard prerequisite for everything else.
+
+---
+
+## Requirements Trace
+
+- R1. Single compose project on the server; `docker compose up -d` brings up everything; survives reboots → U3, U5
+- R2. Ingest is the existing one-shot CLI on a 15-minute schedule; no new daemon code → U3
+- R3. Ingest runs never overlap → U3 (supercronic default no-overlap)
+- R4. `data/receipts` mirrored one-way to Dropbox, additive only → U4
+- R5. Postgres 18 in compose with persistent volume; one-time dump/restore cutover from dev pg:5435 → U3, U6
+- R6. Migrations applied as an explicit deploy step (both migration tables) → U5
+- R7. Search/show/failures via SSH wrapper → U5
+- R8. Secrets in server-side `.env` + server-side rclone config; nothing baked into image → U3, U4, U5
+- R9. Per-cycle summary logging; readable container logs; DLQ inspectable → U2, U3
+
+**Origin flows:** F1 (scheduled ingest → U3), F2 (Dropbox mirror → U4), F3 (search from laptop → U5)
+
+---
+
+## Scope Boundaries
+
+Carried from origin (see origin doc for rationale):
+
+- No push triggers (IMAP IDLE, GDrive webhooks) — polling only
+- No web UI, API, or remote search endpoint
+- No bidirectional Dropbox sync; Dropbox is not an ingest source
+- No CI/CD or registry image delivery — image is built on the server from a git clone
+- Issue #36 (O(N) IMAP enumeration) is not addressed here
+
+### Deferred to Follow-Up Work
+
+- Stale doc cleanup: `docs/user/getting-started.md`, `cli-reference.md`, `troubleshooting.md` still reference the retired `RECEIPT_STORE_PATH` env var — fix opportunistically or as a docs follow-up, not blocking this deploy
+- Starting a `docs/solutions/` learnings KB after this deployment lands (none exists today)
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `Dockerfile` — multi-stage uv build, `appuser` uid/gid 1000, `ENTRYPOINT ["receipt-index"]`; no apt packages, no browsers (the U1 gap)
+- `docker-compose.yml` — dev-only (db + greenmail); stays untouched; pg18 volume must mount at `/var/lib/postgresql` (not a subdir)
+- `Makefile` — golang-migrate v4.18.3 auto-downloaded to `.bin/`; `migrate-up` runs both migration dirs with separate `x-migrations-table` params; requires `MIGRATION_DATABASE_URL` to already contain a `?` query param (Makefile appends with `&`); auto-exports `.env`
+- `src/receipt_index/config.py` — config search order: `--config` flag → `RECEIPT_INDEX_CONFIG` → `./receipt-index.yaml` (CWD-relative) → XDG path. `${VAR}` interpolation hard-fails listing all missing vars
+- `src/receipt_index/cli.py` — `load_dotenv()` at import; `logging.basicConfig` per command to stdout; `ingest` exits 1 if any item failed (per-cycle signal, DLQ'd items never retried); store path resolved relative to CWD (`/app` in container)
+- `src/receipt_index/renderer.py` — render order: PDF pass-through → Playwright Chromium (HTML) → weasyprint fallback; defaults `PLAYWRIGHT_BROWSERS_PATH` to relative `.playwright` if unset — must be set explicitly in the image
+- `src/receipt_index/repository.py` — idempotency = union of `receipts.source_id` and `ingest_log.source_id`; UNIQUE on `source_id` makes races non-corrupting; **no app-level locking** — no-overlap is entirely the scheduler's job
+- `src/receipt_index/store.py` — DB stores paths relative to store root → store tree can be rsynced to the server without DB rewrites
+- `src/receipt_index/auth.py` + `adapters/gdrive.py` — GDrive token lives in env (`GDRIVE_TOKEN_JSON`), refreshed in memory only; headless-safe
+- `db/init/01-create-roles.sql` + `docs/user/production-setup.md` — role/grant pattern (migrations grant to `receipt_index_dev_write`/`_read`); reusable for server Postgres init
+- Known config gotcha: checked-in `receipt-index.yaml` interpolates `${GDRIVE_CREDENTIALS_JSON}` (a key the gdrive source model ignores) — the server `.env` must define it or the deployed YAML must drop the key
+
+### Institutional Learnings
+
+- No `docs/solutions/` KB exists. Carried from CLAUDE.md/project memory: pg18 volume path, dual migration tables, issue #36 poll cost, DLQ needs monitoring when unattended, pdfminer/fontTools log flood (fixed here as U2)
+
+### External References
+
+- supercronic (github.com/aptible/supercronic): waits for a running job before rescheduling — **no-overlap is the default**; `-overlapping` opts out; single static binary; jobs log to stdout
+- rclone Dropbox (rclone.org/dropbox, rclone.org/remote_setup): custom Dropbox app ID recommended (shared rclone ID hits `too_many_requests`); scopes are frozen into the token at authorize time; token auto-refresh **rewrites rclone.conf via file rename** → mount the whole config dir read-write, never `:ro`, never a single-file bind
+- `rclone copy` is additive (never deletes at destination) — matches R4; `rclone sync` would propagate deletions (rejected)
+- Playwright in Docker (playwright.dev/python/docs/docker): install as root with `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` + `playwright install --with-deps --only-shell chromium`, world-readable; pin `python:3.11-slim-bookworm`; `init: true` for zombie reaping; `shm_size: 1gb` (default 64 MB /dev/shm crashes Chromium); Playwright disables the Chromium sandbox by default in containers (enabling it needs a custom seccomp profile); email HTML is **third-party content crossing a trust boundary**, so the compensating control is render-time network egress blocking (U7) rather than seccomp work; browser builds are pinned per Playwright release — rebuild image on every `playwright` bump
+
+---
+
+## Key Technical Decisions
+
+- **supercronic in the app image, compose `entrypoint` override**: no-overlap by default satisfies R3 with zero config; no docker socket exposure (rejected: ofelia needs `/var/run/docker.sock` root-equivalent access; plain sleep-loop drifts and has no missed-tick visibility)
+- **rclone binary installed in the app image, run as a second crontab line**: one scheduler, no sidecar container, no docker socket (rejected: `rclone/rclone` sidecar adds a second scheduling mechanism for no benefit at this scale)
+- **Separate ingest and sync cron lines, offset a few minutes** (e.g. `*/15` and `7,22,37,52`): decoupled so an ingest exit 1 (any single failed item) never blocks the mirror; supercronic's no-overlap applies per job line
+- **Custom Dropbox app ID** in "development" status for a single user: avoids shared-client rate limiting; enable scopes (`files.content.write/read`, `files.metadata.write`, `account_info.read`) *before* authorizing
+- **Separate production compose file** (`deploy/docker-compose.yml`): dev `docker-compose.yml` (db + greenmail) stays untouched; prod file has no greenmail
+- **Postgres bound to `127.0.0.1` host port only** on the server: lets the Makefile migrate target and ad-hoc `psql` run on the server (and from the laptop via SSH tunnel) without exposing the DB (resolves origin deferred question)
+- **Bind mounts for `data/receipts`, config YAML, crontab, and rclone config dir; named volume for pgdata**: receipts tree must be rsync-able and rclone-readable from the host; pgdata never needs host-side access
+- **Explicit `RECEIPT_INDEX_CONFIG=/app/receipt-index.yaml`** in compose env: CWD-relative config discovery is fragile under `docker compose exec -w`
+- **Image built on the server from a git clone** (origin decision): no registry; deploy = `git pull && docker compose build && docker compose up -d`
+- **Production-specific DB init script, not the dev one** (deepening finding, verified against the live source DB): `db/init/01-create-roles.sql` creates `receipt_index_dev_*` roles but *not* `receipt_index` — the login role that owns every object in the dump — and hardcodes `GRANT ... ON DATABASE receipt_index_dev` plus the `localpass` password. Under the postgres image's `ON_ERROR_STOP` init, a different `POSTGRES_DB` name aborts the container on first boot; even if boot succeeds, the restore's `ALTER ... OWNER TO receipt_index` statements fail and the app role is locked out on cycle one. Prod init mirrors the source role set exactly (`receipt_index` login owner + `receipt_index_dev_write`/`_read` nologin members, per `docs/user/production-setup.md`), parameterized DB name, secret password; server `DATABASE_URL` connects as `receipt_index` (owner), matching the source's actual privilege model (table-level ACLs on the live source are NULL — the app-as-owner model is the real one). The init script **also creates `receipt_index_dev_all` (nologin, idempotent)** even though the live source lacks it: migrations `000002`/`000004` GRANT to that role, so a fresh empty server DB cannot pass `make migrate-up` (gate C) without it — verified against the migration files and the live source DB (review finding)
+- **Cutover restore = fresh-database full restore, migrate-up as no-op afterward** (deepening finding): restore the full dump (which carries both `schema_migrations_*` tables at their correct versions — public v1 / receipt v7 today) into an *empty* server DB as the compose superuser, **without** `--no-owner` (so ownership lands on `receipt_index`) and without `--no-acl` (the only ACLs are column grants to roles that exist); then `make migrate-up` verifies as a no-op or applies any post-v7 delta in the repo. Rejected: `--data-only` restore — requires excluding both migration tables, exact version parity, FK-order luck, and collides on UNIQUE(source_id) if the server ever ingested anything
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Scheduler choice (origin deferred): supercronic — see decisions
+- rclone coupling and cadence (origin deferred): second crontab line, offset from ingest; Dropbox destination `dropbox:receipt-index/receipts`
+- Postgres host port exposure (origin deferred): yes, loopback-only
+- pdfminer/fontTools log noise (origin deferred): fixed in app code as U2
+
+### Deferred to Implementation
+
+- Exact pinned versions (supercronic release + sha256, Playwright pip pin, postgres:18 minor, rclone version): read from upstream at build time
+- Whether `--only-shell` Chromium suffices for all real receipt HTML: verify in U1 smoke tests, fall back to full chromium install if a rendering gap appears
+- `rclone copy --immutable` tripwire flag: adopt only after confirming the mid-write-copy caveat is acceptable — supercronic's no-overlap is *per job line*, so a long ingest can overlap a sync tick and rclone may copy a PDF mid-write; today that self-heals on the next pass (size/modtime re-copy), but under `--immutable` it becomes a permanent mismatch. A periodic server-vs-Dropbox count-parity check is the detector either way
+- Server filesystem layout (`/srv/receipt-index` vs `~/receipt-index` clone location): decided in U5 runbook when provisioning
+
+---
+
+## Implementation Units
+
+- U1. **Harden the production image for in-container rendering**
+
+**Goal:** The image can render every receipt type (PDF pass-through, HTML via Playwright Chromium, text via weasyprint) and carries supercronic + rclone binaries.
+
+**Requirements:** R2 (prerequisite), R4; blocks all deployment units
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `Dockerfile`
+- Test: `tests/integration/test_docker_render.py` (new; gated like other integration tests)
+
+**Approach:**
+- Pin base `python:3.11-slim-bookworm` in both stages
+- Final stage, as root before `USER appuser`: apt weasyprint runtime libs (pango, gdk-pixbuf, fontconfig + a font package), `ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, `playwright install --with-deps --only-shell chromium` (via the venv's playwright, world-readable), supercronic binary (pinned release + sha256), rclone binary, and `postgresql-client-18` from the PGDG apt repo (bookworm's default client is v15, older than the v18 server — needed for the nightly pg_dump backup job)
+- Keep `ENTRYPOINT ["receipt-index"]`; the scheduler service overrides entrypoint in compose
+
+**Patterns to follow:**
+- Existing multi-stage uv layout in `Dockerfile`; Microsoft's shared-`PLAYWRIGHT_BROWSERS_PATH` pattern
+
+**Test scenarios:**
+- Happy path: container renders an HTML email fixture to PDF via Playwright as uid 1000 (`docker run --rm --entrypoint python <image> - <<render smoke script>>` style harness)
+- Happy path: weasyprint renders a plain-text fixture to PDF in-container (proves system libs present)
+- Edge case: rendering works with `PLAYWRIGHT_BROWSERS_PATH` as baked into the image (no host env leakage)
+- Error path: image build fails loudly if `playwright install` and the pip `playwright` version drift (document the coupling in a Dockerfile comment)
+
+**Verification:**
+- Both render paths produce non-empty PDFs inside the container as uid 1000; `supercronic -version` and `rclone version` succeed in the image; image builds reproducibly on a clean machine
+
+---
+
+- U2. **Tame third-party library log noise in the CLI entrypoint**
+
+**Goal:** Container logs at INFO are readable: pdfminer, fontTools (and similarly noisy libs) clamped to WARNING regardless of app log level.
+
+**Requirements:** R9
+
+**Dependencies:** None (parallel with U1)
+
+**Files:**
+- Modify: `src/receipt_index/cli.py`
+- Test: `tests/unit/test_cli.py`
+
+**Approach:**
+- After `logging.basicConfig(...)`, set known-noisy library loggers (`pdfminer`, `fontTools`, `PIL`) to WARNING unless the configured app level is DEBUG *and* the user explicitly wants library debug (keep it simple: always clamp; revisit if library debugging is ever needed)
+
+**Patterns to follow:**
+- Existing per-command logging setup in `src/receipt_index/cli.py`
+
+**Test scenarios:**
+- Happy path: with config level INFO, `pdfminer`/`fontTools`/`PIL` loggers are at WARNING after CLI init
+- Edge case: with config level DEBUG, app loggers emit DEBUG while noisy libraries stay clamped
+- Happy path: existing log format/level behavior for `receipt_index.*` loggers unchanged
+
+**Verification:**
+- An ingest run over a PDF-bearing fixture produces no pdfminer/fontTools INFO/DEBUG lines at level INFO
+
+---
+
+- U3. **Production compose project with scheduled ingest**
+
+**Goal:** `docker compose up -d` on the server runs Postgres and a supercronic scheduler that fires `receipt-index ingest` every 15 minutes, no overlap, reboot-safe.
+
+**Requirements:** R1, R2, R3, R5 (service half), R8 (env_file), R9 (per-cycle summary via existing ingest output + supercronic tick logs)
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `deploy/docker-compose.yml`
+- Create: `deploy/crontab`
+- Create: `deploy/receipt-index.yaml` (server config: imap + gdrive sources, `store.path: /app/data/receipts`, INFO logging)
+- Create: `deploy/example.env` (server env template: DB URL, IMAP password, Anthropic key, `GDRIVE_TOKEN_JSON`, `GDRIVE_CREDENTIALS_JSON` if the YAML keeps that key)
+- Create: `deploy/db-init/01-create-roles.sql` (production role init — see Key Technical Decisions; **not** the dev `db/init/` script)
+- Test: none (validated by U5 runbook smoke steps and `docker compose config`)
+
+**Approach:**
+- `db`: `postgres:18`, named volume at `/var/lib/postgresql`, `deploy/db-init/` role scripts (creates `receipt_index` login owner + `receipt_index_dev_write`/`_read`/`_dev_all` nologin members — `_dev_all` is required by migration grants 000002/000004 on a fresh DB; DB name/password from env, nothing hardcoded), healthcheck, `restart: unless-stopped`, ports `127.0.0.1:15432:5432`
+- `scheduler`: built app image; `entrypoint: ["supercronic", "/app/crontab"]`; `init: true`; `shm_size: 1gb`; `restart: unless-stopped`; `depends_on: db: condition: service_healthy`; `env_file: .env`; env `RECEIPT_INDEX_CONFIG=/app/receipt-index.yaml`, `PLAYWRIGHT_BROWSERS_PATH` (match image); bind mounts: `./data/receipts:/app/data/receipts`, `./receipt-index.yaml:/app/receipt-index.yaml:ro`, `./crontab:/app/crontab:ro`, rclone config dir (see U4)
+- Crontab line: `*/15 * * * * receipt-index ingest` — supercronic skips a tick if the previous run is still going (R3); DB is compose-internal hostname `db`
+- **Nightly DB backup crontab line** (review finding — post-cutover, pgdata on one server is otherwise the only copy of receipt metadata, vendor relabels, and the load-bearing ingest_log idempotency state; the Dropbox PDFs cannot be re-ingested): pg_dump against `db` into a bind-mounted `data/backups/` dir with day-of-week filename rotation — bounded at 7 files because `rclone copy` updates changed files (it only never deletes), so the mirror stays bounded too
+- Host bind-mount ownership: `data/receipts`, `data/backups`, and the rclone config dir must be owned by uid/gid 1000 (runbook step in U5)
+
+**Test scenarios:**
+Test expectation: none in pytest — infrastructure config. Validation is behavioral (see Verification) plus `docker compose -f deploy/docker-compose.yml config` lint in U5's deploy steps.
+
+**Verification:**
+- Fresh `docker compose up -d` on a clean host: db healthy, scheduler running; ingest fires on the next 15-minute boundary and logs a cycle summary; a deliberately long-running tick is skipped, not overlapped (observable via supercronic's falling-behind warning); `docker compose restart` and a host reboot both resume the service unattended
+- In-container store-write proof as uid 1000: create/delete a sentinel file under the bind-mounted `data/receipts` from inside the scheduler container (ownership `ls` alone is insufficient — a store-write failure DLQs items exactly like a render gap)
+- `ingest --dry-run` in-container with the real `.env` succeeds — the config loader hard-fails listing every missing `${VAR}`, so one clean dry-run proves env completeness and exercises IMAP/GDrive auth with zero writes and zero DLQ exposure
+- One deliberately failing cycle is observed so the nonzero-exit log signature in supercronic output is known before launch (this is the pattern weekly monitoring greps for)
+
+---
+
+- U4. **Dropbox mirror via rclone cron job**
+
+**Goal:** Every rendered receipt appears in Dropbox within minutes of ingest; deletions/renames on the server never delete anything in Dropbox.
+
+**Requirements:** R4, R8 (rclone token handling)
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Modify: `deploy/crontab` (add sync line)
+- Modify: `deploy/docker-compose.yml` (rclone config dir bind mount)
+- Create: `deploy/rclone-setup.md` (or fold into U5 runbook — one-time Dropbox app + auth procedure)
+- Test: none (one-time OAuth is manual; behavior verified operationally)
+
+**Approach:**
+- One-time (documented, performed on laptop): create a scoped Dropbox app (own client ID/secret; enable `account_info.read`, `files.metadata.write`, `files.content.write`, `files.content.read` **before** authorizing; redirect `http://localhost:53682/`), run `rclone config` locally, scp the resulting config dir to the server
+- Mount the whole rclone config dir **read-write** into the scheduler container (token refresh rewrites `rclone.conf` via rename — `:ro` or single-file mounts break refresh)
+- Crontab line offset from ingest (e.g. `7,22,37,52 * * * *`): `rclone copy /app/data/receipts dropbox:receipt-index/receipts --config /app/.rclone/rclone.conf -v` — `copy` is additive-only per R4
+- Second copy target for the nightly DB dumps: `data/backups/` → `dropbox:receipt-index/backups` (same additive semantics; day-of-week rotation keeps it at 7 objects)
+- No coupling to ingest exit code: sync runs even when a cycle had a failed item
+
+**Test scenarios:**
+Test expectation: none in pytest — external service + one-time OAuth. Operational checks in Verification.
+
+**Verification:**
+- New receipt PDF appears under the Dropbox folder within one sync interval; deleting a file server-side does *not* delete it in Dropbox on subsequent runs; token refresh survives >4 hours unattended (short-lived Dropbox tokens force refresh) with `rclone.conf` updated in place; rate-limit errors absent from logs (custom app ID working)
+- Initial bulk mirror of the full historical tree (the actual rate-limit and correctness stress case, not the single-new-file case): Dropbox file count equals server count afterward
+- rclone remote listing succeeds from inside the container as uid 1000 via the mounted config dir; an induced auth failure's log signature is observed once so weekly monitoring can recognize it
+
+---
+
+- U5. **Deployment runbook, migration step, and SSH search wrapper**
+
+**Goal:** A single document takes a clean Ubuntu server to a running service, and the operator can search from the laptop.
+
+**Requirements:** R1 (reboot durability), R6, R7, R8
+
+**Dependencies:** U3, U4 (documents their artifacts)
+
+**Files:**
+- Create: `docs/user/server-deployment.md`
+- Create: `scripts/receipt-search` (laptop-side SSH wrapper: `ssh receipt-server docker compose -f ... exec scheduler receipt-index "$@"` shape)
+- Modify: `docs/user/production-setup.md` (pointer note: native-PG setup superseded by server deployment for this project)
+- Test: none — documentation + trivial wrapper script
+
+**Approach:**
+- Runbook sections: server prerequisites (Docker Engine + compose plugin, boot-enabled); clone + `.env` provisioning from 1Password (never committed); bind-mount dir creation with uid 1000 ownership; image build; **migrations as an explicit step** — run `make migrate-up` on the server against `127.0.0.1:15432` with `MIGRATION_DATABASE_URL` containing `?sslmode=disable` (Makefile appends `&x-migrations-table=...`; golang-migrate auto-downloads to `.bin/`); `docker compose up -d`; smoke checks (`docker compose logs`, `receipt-index failures`); upgrade procedure (`git pull && docker compose build && up -d`, re-run migrations)
+- **First-launch Go/No-Go gates**, ordered, each a hard stop, with the 15-minute schedule on real mail enabled *last* (the DLQ converts launch-day environmental failures into permanent skips): A) render smoke on the server-built image, both engines, as uid 1000; B) platform — compose lints, db healthy, pgdata at `/var/lib/postgresql`, in-container sentinel write to the store bind mount and the rclone config dir; C) schema — migration tables at expected versions (recorded in the runbook), not dirty; app-role read path proven via in-container `search`; D) `ingest --dry-run` with the real `.env` (complete env/auth proof, zero writes); E) cutover parity + DLQ baseline recorded (see U6); F) Dropbox — remote listing as uid 1000, initial bulk mirror count-verified; G) one supervised manual cycle, then enable the schedule, observe two automatic ticks, then the reboot test against the final config
+- **Pre-cutover smoke is `ingest --dry-run`, not a real ingest** — a real smoke ingest would leave the server DB and store non-empty, breaking U6's fresh-database restore precondition (deepening finding)
+- **Monitoring section (weekly, solo-operator)**: compare the **full per-status ingest_log breakdown (success/skipped/failed) against the cutover baseline** — not just `failures`. A low-confidence receipt is logged as `skipped`, exits 0, never appears in `receipt-index failures` (which filters `status='failed'` only), and is permanently skipped — the silent half of the data-loss surface, with real precedent (amount:0 saga, payment confirmations). The runbook includes a documented SQL query to list new `skipped` rows' subject/sender for eyeball review; a `failures --status skipped` CLI flag is named as future work. Also: compose-log scan for nonzero ingest exits and supercronic falling-behind warnings (the latter is the issue-#36 early-warning); Dropbox freshness — newest-file timestamp checkable from any device with no SSH, the free end-to-end delivery check (confirms liveness only when receipts were expected in the window). Name as future work: a crontab line pinging a healthchecks.io-style dead-man's-snitch URL after each successful cycle
+- **DLQ recovery procedure**: after fixing an environmental cause (render, perms, network), delete the affected `failed` ingest_log rows to force retry; content failures will simply re-fail
+- **Disaster recovery from Dropbox**: restore procedure using the newest `backups/` dump (DB) plus the mirrored `receipts/` tree (files) onto a rebuilt server — the full-loss story, documented while everything works
+- SSH wrapper covers `search`, `show`, `failures`; note that `docker compose exec` needs the scheduler container running (it always is)
+- Include the `GDRIVE_CREDENTIALS_JSON` interpolation gotcha in the env checklist
+
+**Test scenarios:**
+Test expectation: none — docs and a passthrough script; validated by executing the runbook end-to-end on the real server (Verification).
+
+**Verification:**
+- A fresh follow-the-runbook pass on the server reaches a healthy `docker compose ps` with migrations applied and a clean in-container `ingest --dry-run`; `scripts/receipt-search search --vendor foo` returns results from the laptop (post-cutover); every Go/No-Go gate has a concrete pass criterion written in the runbook
+
+---
+
+- U6. **Data cutover from dev machine to server**
+
+**Goal:** All existing receipts (DB rows + PDF tree) live on the server; the dev pg:5435 instance is retired for this project; no receipt is double-processed or lost.
+
+**Requirements:** R5
+
+**Dependencies:** U5 (runbook exists, service deployed but scheduler paused during cutover)
+
+**Files:**
+- Modify: `docs/user/server-deployment.md` (one-time cutover appendix: procedure + verification queries)
+- Test: none — one-time operational procedure with explicit verification queries
+
+**Approach:**
+- Preconditions (deepening findings, verified against the live source DB): server DB is *empty* at cutover start — if U5 smoke steps or a stray cycle touched it, drop/recreate first, and verify server `ingest_log` has zero rows immediately before restore ("paused" is proven, not assumed). The rsync target store is likewise empty (additive rsync over smoke-test leftovers strands orphan PDFs — LLM vendor extraction isn't deterministic enough for filenames to collide cleanly)
+- Laptop stop is *enforced*, not habitual: rename the laptop `.env`/config at cutover start so an accidental `receipt-index ingest` cannot connect; take the dump strictly after the last laptop run completes; retain the dump file as the rollback artifact (on abort, re-restore from the *same* dump — never re-dump)
+- Sequence: enforce laptop stop → `pg_dump` from dev pg:5435 → fresh-database full restore as compose superuser, no `--no-owner`, no `--no-acl` (see Key Technical Decisions; requires the `receipt_index` role from `deploy/db-init/`; the dump carries `pg_trgm`, both `schema_migrations_*` tables, and all ownership) → `make migrate-up` as verification no-op (or applies any post-v7 delta in the repo — the only correct ordering) → checksum-verified rsync of `data/receipts` → chown uid 1000 → run initial Dropbox bulk mirror and count-verify (cutover is not complete without it; do **not** enable the sync cron line before verification passes — `rclone copy` is additive, so a bad cutover mirrored to Dropbox never self-cleans) → supervised cycle, then enable schedule
+- No sequence resync required — verified: no sequences, serial, or identity columns exist in either schema (UUID v7 defaults throughout)
+- source_id stability across machines is verified (IMAP Message-ID / content-hash fallback, GDrive file ID) — the first server cycle re-enumerates the full mailbox but skips everything already known
+- `ingest_log` is load-bearing data, not "just a log": idempotency is the *union* of `receipts.source_id` and `ingest_log.source_id` — if only `receipts` survives the restore, historical skipped/failed items get reprocessed (LLM spend, and previously-skipped items may insert under model drift)
+- Retire: point of no return is the first server cycle that ingests genuinely new mail — before it, abort = stop scheduler, drop server DB, re-restore from the retained dump; after it, the laptop DB is stale and recovery means reverse-cutover, not rollback. Drop dev pg only after an explicit criterion — e.g. 7 days with zero `failures` growth, no falling-behind warnings, and Dropbox count parity — and take a final dump immediately before the drop (the plan's only irreversible step)
+
+**Test scenarios:**
+Test expectation: none — operational cutover; the verification queries below are the acceptance test.
+
+**Verification:**
+- Strongest single number: distinct `source_id` union count (receipts ∪ ingest_log) on the server equals the value captured from the source at dump time; plus per-table row counts and the per-status ingest_log breakdown (success/skipped/failed) — the breakdown is recorded in the runbook as the monitoring baseline. Note: receipts ≫ ingest_log rows is *expected* (pre-DLQ-era receipts have no log rows) — do not "fix" it
+- Verification queries run **as the app role over the app DSN**, not as superuser — the only check that catches the ownership/grant lockout failure class; include the idempotency UNION query itself
+- Referential file check: every `pdf_path` in the restored DB resolves to an existing file under the server store root (0 missing); orphan files counted separately (tolerable)
+- Schema integrity: `pg_trgm` extension present and the vendor trigram index exists post-restore (a partially-errored restore can leave counts right and indexes silently missing)
+- First-cycle duplicate check, made concrete: zero `ingest_log` rows created after cutover whose `source_id` belongs to a receipt with pre-cutover `created_at` — duplicates cannot appear as double rows (UNIQUE), only as fresh log rows for old items
+- A known historical receipt (e.g., a known utility or lease receipt) is searchable and `show`-able via the laptop wrapper
+
+---
+
+- U7. **Block network egress during HTML-to-PDF rendering**
+
+**Goal:** A rendered email cannot make outbound network requests: receipt HTML is third-party content processed unattended 96×/day with Chromium's sandbox disabled, in a container holding every credential the service owns — egress blocking removes the exfiltration/phone-home path if a renderer exploit ever lands, and as a side effect makes PDFs deterministic (no remote images/trackers fetched at render time).
+
+**Requirements:** Plan-local security hardening (no origin R-ID; accepted during document review in place of risk-acceptance)
+
+**Dependencies:** None (parallel with U1/U2; must land before first unattended cycle, i.e., before U3 goes live)
+
+**Files:**
+- Modify: `src/receipt_index/renderer.py`
+- Test: `tests/unit/test_renderer.py`
+
+**Approach:**
+- Playwright path: intercept all requests in the render context and abort anything that is not the inline document itself (route-level block; no remote fetches)
+- weasyprint path: supply a URL fetcher that refuses remote URLs, for parity
+- Expect blank boxes where receipts referenced remote images — acceptable; the receipt's text content is what extraction and reconciliation use
+
+**Patterns to follow:**
+- Existing renderer structure in `src/receipt_index/renderer.py` (Playwright primary, weasyprint fallback)
+
+**Test scenarios:**
+- Happy path: HTML with only inline content renders to a non-empty PDF with egress blocking active
+- Happy path: HTML referencing a remote image renders successfully with the image blocked (no network attempt, no exception)
+- Error path: a render must not hang or fail outright because a remote resource is unreachable-by-policy (blocked ≠ timeout)
+- Integration: weasyprint fallback path also refuses a remote URL via the custom fetcher
+
+**Verification:**
+- A render of a fixture containing remote references completes with zero outbound network requests observed (assertable via Playwright's route interception in tests); both engines produce non-empty PDFs
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** dev `docker-compose.yml`, Makefile test targets, and CI are untouched; the only shared-surface change is `Dockerfile` (U1) — CI builds of the image (if any) get bigger/slower, and `src/receipt_index/cli.py` (U2) — all CLI commands gain the log clamp
+- **Error propagation:** ingest exit 1 on any failed item is a *per-cycle* signal, not a stuck state (failed items are DLQ'd and never retried); supercronic logs the non-zero exit and fires the next tick normally; rclone sync is deliberately decoupled from ingest exit codes
+- **State lifecycle risks:** DLQ permanence is the sharp edge — a receipt that fails once (e.g., rendering gap) is never retried. Pre-cutover render smoke tests (U1) and a post-deploy `failures` check in the runbook mitigate; recovery path (delete the failed `ingest_log` rows to force retry) documented in the runbook
+- **API surface parity:** none — no CLI or schema changes beyond log levels
+- **Integration coverage:** U1's in-container render tests are the load-bearing cross-layer proof; everything else is validated operationally per unit Verification
+- **Unchanged invariants:** dev workflow (`docker compose up -d` + GreenMail + `make test-integration`), migration file contents, DB schema, receipt file naming, and the CLI's command surface all stay exactly as they are
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Rendering deps gap → silent permanent data loss via DLQ | U1 first; in-container render tests for both engines; runbook step checks `failures` after first cycles; documented DLQ-row deletion recovery |
+| Dropbox token refresh breaks (config mounted wrong) | Whole-dir read-write mount (rename-safe); U4 verification includes a >4h unattended refresh check |
+| Shared rclone app ID rate limits | Custom Dropbox app ID from day one |
+| Overlapping ingest runs | supercronic default no-overlap; app-level UNIQUE(source_id) makes a worst-case race non-corrupting |
+| pg18 volume path mistake loses data on restart | Volume at `/var/lib/postgresql` (known learning, already correct in dev compose); runbook copies the pattern |
+| IMAP poll cost grows with mailbox size (issue #36) | Accepted per origin scope; 15-min cadence revisited if cycles start approaching the interval (supercronic falling-behind warnings make this visible) |
+| Cutover races (laptop and server both ingesting) | Enforced laptop stop (config renamed so accidental ingest can't connect); dump taken after last laptop run; idempotency union makes accidental overlap non-corrupting |
+| Restore leaves app role locked out (dev init script lacks `receipt_index` owner role; dev DB-name grant aborts container init) | Production-specific `deploy/db-init/` role script mirroring the source role set; restore without `--no-owner`; verification queries run as the app role |
+| Restore into a non-empty server DB (U5 smoke leftovers) corrupts migration state or collides on UNIQUE(source_id) | Fresh-database restore precondition; pre-cutover smoke is `--dry-run` only; server `ingest_log` verified empty immediately before restore |
+| Sync copies a PDF mid-write (no-overlap is per cron line) | Self-heals on next pass under plain `copy`; blocks adopting `--immutable` until accepted; count-parity check is the detector |
+| Renderer exploit via malicious email HTML (Chromium sandbox disabled in-container, unattended processing) | U7 blocks all render-time network egress — a compromised render cannot phone home or exfiltrate the container's credentials; full seccomp sandbox enablement remains a future option |
+| Server disk/host failure after dev pg retirement destroys the only DB copy | Nightly rotating pg_dump into the Dropbox-mirrored `data/backups/` tree; restore-from-Dropbox procedure in the runbook |
+
+---
+
+## Documentation / Operational Notes
+
+- `docs/user/server-deployment.md` becomes the canonical ops doc (deploy, upgrade, Go/No-Go gates, cutover appendix, DLQ recovery, monitoring baseline, SSH wrapper)
+- Weekly ops routine (baseline-driven, see U5): full per-status ingest_log breakdown vs recorded baseline (skipped growth matters as much as failed); log scan for nonzero exits and falling-behind warnings; Dropbox newest-file freshness as the no-SSH delivery check
+- Future work (named, not scoped): dead-man's-snitch ping (healthchecks.io-style) as a third crontab line after successful cycles — absence-of-ping covers crash-loop, falling-behind, and config breakage in one mechanism
+- Anthropic spend: polling itself costs no LLM calls; per-poll cost is IMAP/GDrive enumeration only
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-08-01-always-on-service-requirements.md](../brainstorms/2026-08-01-always-on-service-requirements.md)
+- Related code: `Dockerfile`, `docker-compose.yml`, `Makefile`, `src/receipt_index/{cli,config,renderer,repository,store}.py`, `db/init/01-create-roles.sql`
+- Related issues: #36 (IMAP O(N) enumeration — accepted, out of scope)
+- External docs: github.com/aptible/supercronic · rclone.org/dropbox · rclone.org/remote_setup · playwright.dev/python/docs/docker

--- a/docs/user/production-setup.md
+++ b/docs/user/production-setup.md
@@ -1,5 +1,9 @@
 # Production Setup
 
+> **Superseded for this project.** The native-PostgreSQL setup below is how receipt-index ran on the dev machine before it moved to the always-on Docker service. That deployment — compose-managed Postgres, scheduled ingest, Dropbox mirror, and the one-time cutover off this native cluster — is documented in **[Server Deployment](server-deployment.md)**, which is now the canonical operations document.
+>
+> This page remains valid if you want a host-based install with your own PostgreSQL server.
+
 Run Receipt Search Index against a native PostgreSQL 18 server instead of Docker. This is suitable for a host-based deployment where you want to ingest and search your full set of receipts.
 
 ## 1. Install PostgreSQL 18

--- a/docs/user/server-deployment.md
+++ b/docs/user/server-deployment.md
@@ -1,0 +1,866 @@
+# Server Deployment
+
+Take a clean Ubuntu box to an unattended receipt-index service: Postgres in Docker, `receipt-index ingest` on a 15-minute schedule, receipts and nightly database dumps mirrored to Dropbox.
+
+This is the canonical operations document for the always-on deployment — provisioning, first-launch gates, the one-time cutover from the dev machine, weekly monitoring, upgrades, and disaster recovery.
+
+> **Not this document:** [Production Setup](production-setup.md) describes running against a native PostgreSQL server on the dev machine. That is the arrangement this deployment replaces.
+
+**Contents**
+
+1. [Overview and layout](#1-overview-and-layout)
+2. [Server prerequisites](#2-server-prerequisites)
+3. [Provisioning](#3-provisioning)
+4. [Build and migrate](#4-build-and-migrate)
+5. [First-launch Go/No-Go gates](#5-first-launch-gono-go-gates)
+6. [Cutover from the dev machine (one-time)](#6-cutover-from-the-dev-machine-one-time)
+7. [Weekly monitoring](#7-weekly-monitoring)
+8. [Routine operations](#8-routine-operations)
+9. [Searching from the laptop](#9-searching-from-the-laptop)
+
+---
+
+## 1. Overview and layout
+
+One Docker Compose project, named `receipt-index` (set by `name:` at the top of `deploy/docker-compose.yml`), with two services:
+
+| Service | What it is |
+|---|---|
+| `db` | `postgres:18`, named volume `pgdata`, published on `127.0.0.1:15432` only |
+| `scheduler` | The app image with `supercronic /app/crontab` as its entrypoint — ingest every 15 min, two rclone mirror lines, one nightly `pg_dump` |
+
+**The git clone is the deployment unit.** There is no registry and no CI: the image is built on the server from the checkout, and deploying an update is `git pull` + rebuild. Everything the server needs beyond the clone is a handful of git-ignored files at the clone root.
+
+Documented clone location: **`~/receipt-index`**, in the home directory of the login user you SSH in as. That user should be uid/gid 1000, which is also the image's `appuser` — so the bind-mounted directories need no `sudo` to manage and files written by the container are readable by you. `/srv/receipt-index` works equally well if you prefer a system location; every command below is run from the clone root, so only the `cd` changes, but you will need `sudo` for the `chown` steps.
+
+Layout after provisioning:
+
+```
+~/receipt-index/                 <- clone root; all compose commands run from here
+├── .env                         <- secrets (git-ignored, chmod 600)
+├── data/
+│   ├── receipts/                <- rendered PDF tree      (uid 1000)
+│   └── backups/                 <- nightly pg_dump files  (uid 1000)
+├── rclone-config/               <- Dropbox token          (uid 1000, chmod 700)
+└── deploy/
+    ├── docker-compose.yml       <- the production compose file
+    ├── crontab                  <- supercronic schedule
+    ├── backup.sh                <- nightly dump script
+    ├── example.receipt-index.yaml  <- config template (copy + edit, see 3.2b)
+    ├── receipt-index.yaml       <- your copy (git-ignored; no secrets, only ${VAR})
+    ├── db-init/01-create-roles.sh
+    ├── example.env
+    └── rclone-setup.md
+```
+
+Compose resolves relative paths against the directory holding the compose file, so `deploy/docker-compose.yml` refers to the four state directories with a `../` prefix (`../.env`, `../data/receipts`, `../data/backups`, `../rclone-config`) and to its own siblings with `./`. That is why `.env` belongs at the **clone root** and not in `deploy/`.
+
+Every command in this document assumes:
+
+```bash
+cd ~/receipt-index
+```
+
+and uses the explicit `-f deploy/docker-compose.yml` form, so the repo-root `docker-compose.yml` (the dev stack: db + GreenMail) is never picked up by accident.
+
+Laptop-side commands use **`receipt-server`** as the SSH target. Either define that alias in `~/.ssh/config` (recommended — the search wrapper defaults to it) or substitute your server's hostname wherever it appears.
+
+---
+
+## 2. Server prerequisites
+
+- **Docker Engine + the Compose v2 plugin.** Install from Docker's own apt repository, not the distro `docker.io` package (which lags and does not ship `docker compose`).
+
+  ```bash
+  docker --version
+  docker compose version        # must print "Docker Compose version v2..." or newer
+  ```
+
+- **Docker enabled at boot** — everything about reboot survival depends on this, because the containers' `restart: unless-stopped` policies only apply once the daemon is running:
+
+  ```bash
+  sudo systemctl enable --now docker
+  systemctl is-enabled docker   # must print "enabled"
+  ```
+
+- **The deploy user in the `docker` group** (`sudo usermod -aG docker $USER`, then log out and back in), so `docker compose` and the SSH search wrapper work without `sudo`.
+
+- **Outbound network**: HTTPS/443 to `api.anthropic.com`, `www.googleapis.com`, `api.dropboxapi.com` and `content.dropboxapi.com`, plus **IMAPS/993** to your IMAP provider. No inbound ports are needed; the database is published on loopback only.
+
+- **`git`, `make`, `curl`** — `make migrate-up` downloads golang-migrate into `.bin/` with curl.
+
+- **`uv`** ([docs.astral.sh/uv](https://docs.astral.sh/uv/)) — only for Gate A, which runs the in-container render tests from the repo's test suite. Skip it if you accept the manual fallback in Gate A.
+
+- **Disk**: the pgdata volume, the receipt tree, seven database dumps, and capped container logs (10 MB × 7 per service). A few GB is plenty; check with `df -h` before starting.
+
+---
+
+## 3. Provisioning
+
+### 3.1 Clone
+
+```bash
+git clone https://github.com/rmorison/receipt-index.git ~/receipt-index
+cd ~/receipt-index
+```
+
+### 3.2 Create `.env` at the clone root
+
+```bash
+cp deploy/example.env .env
+chmod 600 .env
+```
+
+`deploy/example.env` documents every variable. Real values come from 1Password (`.env` is git-ignored and is never committed):
+
+| Variable | Source |
+|---|---|
+| `POSTGRES_PASSWORD` | Generate: `openssl rand -hex 24` |
+| `RECEIPT_INDEX_PASSWORD` | Generate: `openssl rand -hex 24` — must match the password inside `DATABASE_URL` |
+| `IMAP_PASSWORD` | 1Password — your IMAP mailbox item |
+| `ANTHROPIC_API_KEY` | 1Password (Personal) — *Anthropic receipt-index api key* |
+| `GDRIVE_TOKEN_JSON` | Output of `receipt-index auth gdrive --client-credentials <client_secret.json>`, run on the laptop |
+
+### 3.2b Create the server app config
+
+```bash
+cp deploy/example.receipt-index.yaml deploy/receipt-index.yaml
+```
+
+Edit the copy (it is git-ignored) with your real source definitions: IMAP host, username, and folder, and the Google Drive folder id. Secrets stay as `${VAR}` references into `.env`.
+
+`GDRIVE_CREDENTIALS_JSON` is **not** required on the server. The template deliberately drops that key from the gdrive source, and the OAuth client id/secret needed for refresh already live inside `GDRIVE_TOKEN_JSON`. (The dev config may still interpolate it; do not copy that line over.)
+
+Also do **not** set `PLAYWRIGHT_BROWSERS_PATH` in the server `.env`. The image bakes `/ms-playwright`; the dev value (`.playwright`) is a relative path that does not exist in the container, and if it leaks in, every HTML receipt fails to render and is permanently dead-lettered.
+
+### 3.3 The `$`-in-secrets hazard — read before pasting a password
+
+Docker Compose performs variable expansion on values inside an `env_file`. **A secret containing `$` is silently corrupted.** Verified behaviour: a value written as
+
+```
+IMAP_PASSWORD=ab$wcd$$ef
+```
+
+is delivered to the container as `ab$ef` — `$wcd` expands to the empty string (compose only mutters `The "wcd" variable is not set` on stderr) and `$$` collapses to a literal `$`. Authentication then fails with an error that says nothing about the real cause. `make`, which also reads this file, has the same hazard.
+
+Rules:
+
+- Escape every literal dollar sign by doubling it: `ab$wcd` → `ab$$wcd`.
+- Applies to `IMAP_PASSWORD`, `ANTHROPIC_API_KEY`, both Postgres passwords, and the passwords embedded in `DATABASE_URL` / `MIGRATION_DATABASE_URL`.
+- Generate the Postgres passwords from an alphanumeric alphabet (`openssl rand -hex 24`) so the question never comes up for those.
+
+Two checks. First, no expansion warnings at all:
+
+```bash
+docker compose -f deploy/docker-compose.yml config --quiet     # must print nothing
+```
+
+Second — the check that actually proves it, because a *defined* variable expands silently with no warning — compare the value **as the container sees it** against 1Password, hashed so nothing is printed:
+
+```bash
+# In the container (uid 1000, real .env, real compose expansion):
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler \
+    -c 'printf %s "$IMAP_PASSWORD" | sha256sum'
+
+# On the laptop, from 1Password (adjust the field reference to the item):
+op read "op://Personal/<your-imap-item>/password" | tr -d '\n' | sha256sum
+```
+
+The two digests must match. Repeat for `ANTHROPIC_API_KEY`. Do this **before** Gate D — a corrupted key surfaces there as an opaque auth failure.
+
+### 3.4 Create the bind-mount directories *before* the first `up -d`
+
+Docker creates a missing bind-mount source as an empty directory owned by `root:root`. The container runs as uid 1000 and cannot write to it — and a store-write failure dead-letters receipts exactly like a render gap does. Create them first:
+
+```bash
+mkdir -p data/receipts data/backups rclone-config
+chown -R 1000:1000 data/receipts data/backups rclone-config   # sudo if not your uid
+chmod 700 rclone-config                                        # holds a standing Dropbox refresh token
+```
+
+`chmod 700` on `rclone-config/` is not decoration: `rclone.conf` contains a long-lived Dropbox refresh token with write access to the mirror.
+
+### 3.5 One-time rclone/Dropbox authorization
+
+Follow **[deploy/rclone-setup.md](../../deploy/rclone-setup.md)**: create a dedicated Dropbox app (own client ID — the shared rclone ID is rate-limited during a bulk mirror), enable the four scopes *before* authorizing, run `rclone config` on the laptop, then `scp -r` the config **directory** to `~/receipt-index/rclone-config` and re-apply the ownership and mode above.
+
+The mount is a whole directory, read-write, on purpose: Dropbox access tokens expire in about four hours and rclone refreshes them by writing a temp file and renaming it over `rclone.conf`. A `:ro` mount or a single-file bind mount breaks the rename and the mirror dies silently a few hours after a deploy that looked fine.
+
+---
+
+## 4. Build and migrate
+
+### 4.1 Build the image on the server
+
+```bash
+docker compose -f deploy/docker-compose.yml build
+```
+
+This tags `receipt-index:latest` (the compose `image: receipt-index` key), which is what Gate A's tests look for by default.
+
+### 4.2 Start only the database
+
+```bash
+docker compose -f deploy/docker-compose.yml up -d db
+docker compose -f deploy/docker-compose.yml ps          # db must reach "healthy"
+```
+
+The scheduler stays down. **Starting the scheduler is what enables the schedule**, and that is the last thing that happens on launch day (see Gate G). Everything before then runs as one-off `docker compose run --rm` commands.
+
+On first boot of an empty volume, `deploy/db-init/01-create-roles.sh` runs once and creates the `receipt_index` login role (owner of the database and of schema `public`) plus the three NOLOGIN grant-target roles the migrations reference by name (`receipt_index_dev_all` / `_write` / `_read`). It never runs again — a later role change is an `ALTER ROLE`, by hand.
+
+### 4.3 Apply migrations — an explicit deploy step
+
+Migrations are **not** run by the container. They are a deliberate host-side step, before the scheduler ever starts, and again after every upgrade.
+
+Set `MIGRATION_DATABASE_URL` in `.env`. It connects over the loopback-published host port, and it **must already contain a `?` query parameter** — the Makefile appends `&x-migrations-table=...` to whatever you give it, so a URL without `?sslmode=disable` is malformed and golang-migrate fails to connect:
+
+```
+MIGRATION_DATABASE_URL=postgresql://receipt_index:<RECEIPT_INDEX_PASSWORD>@127.0.0.1:15432/receipt_index?sslmode=disable
+```
+
+**Run migrations as the `receipt_index` role, not as the superuser.** `receipt_index` owns the database and schema `public` (via `db-init`), and the cutover dump restores every object owned by `receipt_index`. If migrations run as `postgres`, a freshly built server ends up with schema `receipt` and its tables owned by the superuser while a restored server has them owned by the app role — two servers with divergent ownership from the same repo. The app role has everything it needs: `pg_trgm` is a *trusted* extension in Postgres 13+, so the database owner can `CREATE EXTENSION` without superuser.
+
+> `deploy/example.env` ships this line with the `receipt_index` role already in place — migrations run as the database owner, not the superuser. The superuser credentials (`POSTGRES_PASSWORD`) are still needed separately for the cutover `pg_restore` (section 6).
+
+Then:
+
+```bash
+make migrate-up
+```
+
+The Makefile auto-exports `.env`, downloads golang-migrate v4.18.3 into `.bin/` if absent, and applies both migration directories with separate version tables (`schema_migrations_public`, `schema_migrations_receipt`) — both directories start at `000001`, so a shared table would corrupt the state.
+
+---
+
+## 5. First-launch Go/No-Go gates
+
+Run these in order. **Each is a hard stop**: do not proceed to the next gate until the current one passes.
+
+The ordering is not ceremony. Failed items land in `ingest_log` and are then permanently skipped — the idempotency check is the union of `receipts.source_id` and `ingest_log.source_id`, and nothing ever retries a dead-lettered item. A launch-day environmental failure (missing browser, unwritable mount, bad credential) therefore does not present as an outage; it presents as **receipts that silently never appear**, one per message the scheduler touched while broken. So the 15-minute schedule on real mail is enabled **last**, after everything it depends on has been proven.
+
+### Gate A — rendering works in the server-built image
+
+Both render engines must work *in the image built on this server*, as uid 1000.
+
+```bash
+uv sync --all-extras
+RECEIPT_INDEX_IMAGE=receipt-index:latest \
+    uv run pytest tests/integration/test_docker_render.py -m integration --no-cov
+```
+
+**Pass:** all tests green. That covers Playwright/Chromium rendering an HTML receipt, weasyprint rendering a text receipt (which proves the pango/gdk-pixbuf system libraries are present), `PLAYWRIGHT_BROWSERS_PATH` resolving to the image's baked `/ms-playwright` even when the host value is poisoned, and `supercronic` / `rclone` / `pg_dump` all being on `PATH` — with `pg_dump` reporting version 18 (an older client cannot dump a v18 server). Every script asserts `os.getuid() == 1000` internally.
+
+If the tests skip, the image tag is wrong — `docker image inspect receipt-index:latest`.
+
+*Without uv on the server*, the minimum manual equivalent:
+
+```bash
+docker run --rm --shm-size=1g --entrypoint python receipt-index:latest -c '
+import os
+from receipt_index.renderer import _html_to_pdf_playwright
+assert os.getuid() == 1000
+pdf = _html_to_pdf_playwright("<html><body><h1>smoke</h1></body></html>")
+assert pdf[:5] == b"%PDF-"
+print("playwright OK", len(pdf))'
+```
+
+but prefer the test file — it is the version that stays in sync with the code.
+
+### Gate B — platform
+
+```bash
+# 1. Compose file lints and every referenced variable resolves
+docker compose -f deploy/docker-compose.yml config --quiet
+
+# 2. Database is healthy
+docker compose -f deploy/docker-compose.yml ps
+
+# 3. pgdata is on the volume mounted at /var/lib/postgresql (NOT a subdirectory)
+docker compose -f deploy/docker-compose.yml exec db \
+    sh -c 'echo "$PGDATA"; ls -d "$PGDATA"'
+
+# 4. Sentinel write as uid 1000 to both writable mounts
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler -c '
+    id -u
+    touch /app/data/receipts/.sentinel && rm /app/data/receipts/.sentinel
+    touch /app/data/backups/.sentinel  && rm /app/data/backups/.sentinel
+    touch /app/.rclone/.sentinel       && rm /app/.rclone/.sentinel
+    echo ALL-MOUNTS-WRITABLE'
+```
+
+**Pass:** (1) prints nothing at all — any `variable is not set` warning is a broken `.env`; (2) `db` shows `healthy`; (3) `PGDATA` is `/var/lib/postgresql/18/docker`, i.e. *inside* the volume mounted at `/var/lib/postgresql` — if the volume were mounted at `/var/lib/postgresql/data` instead, the cluster would live outside the volume and vanish on the next container restart; (4) prints `1000` then `ALL-MOUNTS-WRITABLE`.
+
+A host-side `ls -l` is **not** a substitute for step 4. Only a write from inside the container as uid 1000 proves the thing that matters.
+
+### Gate C — schema
+
+```bash
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler -c '
+    psql "$DATABASE_URL" -c "SELECT '\''public'\'' AS dir, version, dirty FROM schema_migrations_public
+                             UNION ALL
+                             SELECT '\''receipt'\'', version, dirty FROM schema_migrations_receipt;"'
+```
+
+**Pass — record these numbers in your deploy notes:**
+
+| Migration table | Expected version | dirty |
+|---|---|---|
+| `schema_migrations_public` | `1` | `f` |
+| `schema_migrations_receipt` | `7` | `f` |
+
+(As of 2026-08-01. A `dirty = t` means a migration aborted half-applied; fix it before anything else touches the database.)
+
+Then prove the **application** read path — same role, same DSN, same container the scheduler will use:
+
+```bash
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint receipt-index scheduler \
+    search --vendor zzz-no-such-vendor --output json
+```
+
+**Pass:** exit 0 and `[]` on a pre-cutover (empty) database. This is the check that catches an ownership/grant lockout — the failure mode where the schema is perfect and the app still cannot read it.
+
+### Gate D — environment and credentials, with zero writes
+
+```bash
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint receipt-index scheduler \
+    ingest --dry-run
+```
+
+One clean dry run proves three things at once: the config loader resolved every `${VAR}` in `deploy/receipt-index.yaml` (a missing one hard-fails and lists *all* of them), IMAP authenticated, and the Google Drive token refreshed — all with no database writes, no rendering, and therefore no dead-letter exposure.
+
+> **Not a hang.** On an empty database the dry run enumerates the *entire* historical mailbox, because nothing is known yet. It is slow and extremely log-heavy. Let it finish. (This is issue #36's O(N) enumeration; after cutover it is fast again because the union of known `source_id`s is populated.)
+
+**Pass:** exits 0, having listed the candidate items.
+
+### Gate E — cutover parity and DLQ baseline
+
+Perform **[section 6](#6-cutover-from-the-dev-machine-one-time)** in full, including every verification query.
+
+**Pass:** the distinct `source_id` union count on the server equals the value captured from the source at dump time; the per-status `ingest_log` breakdown is recorded in your deploy notes as the monitoring baseline; every `pdf_path` resolves to a file.
+
+### Gate F — Dropbox
+
+```bash
+# Remote listing as uid 1000, through the mounted config directory
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint rclone scheduler \
+    lsd dropbox: --config /app/.rclone/rclone.conf
+
+# Initial bulk mirror (post-cutover: the full historical tree)
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint rclone scheduler \
+    copy /app/data/receipts dropbox:receipt-index/receipts \
+    --config /app/.rclone/rclone.conf -v
+
+# Count parity
+find data/receipts -type f | wc -l
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint rclone scheduler \
+    size dropbox:receipt-index/receipts --config /app/.rclone/rclone.conf
+```
+
+**Pass:** `lsd` succeeds as uid 1000, the bulk copy completes with no `too_many_requests` errors in its output (if you see them, the remote is using rclone's shared client ID — redo `deploy/rclone-setup.md` step 1), and the Dropbox object count equals the server file count.
+
+The bulk mirror is the real stress case, not the one-new-file case, and it must pass **before** the scheduler starts: `rclone copy` is additive and never deletes, so a mirror of a bad cutover does not self-clean.
+
+### Gate G — supervised cycle, then the schedule
+
+```bash
+# 1. One supervised cycle, watched end to end
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint receipt-index scheduler \
+    ingest --limit 1
+```
+
+Note the `--entrypoint receipt-index`: the service's entrypoint is `supercronic /app/crontab`, so a bare `run scheduler receipt-index ingest` would append the CLI as *arguments to supercronic*. Once the scheduler is running, `exec` is the more convenient form (`exec` ignores the entrypoint):
+
+```bash
+docker compose -f deploy/docker-compose.yml exec scheduler receipt-index ingest --limit 1
+```
+
+**Pass:** exit 0, a PDF appears under `data/receipts`, the corresponding `receipts` row exists, and `receipt-index failures` shows nothing new.
+
+```bash
+# 2. Enable the schedule — this starts supercronic and all four cron lines
+docker compose -f deploy/docker-compose.yml up -d
+
+# 3. Watch two automatic ticks (at :00/:15/:30/:45)
+docker compose -f deploy/docker-compose.yml logs -f scheduler
+```
+
+**Pass, after two automatic ticks:**
+
+- Zero duplicate `source_id` processing — the first-cycle duplicate query in [section 6.6](#66-verification-queries) still returns `0`.
+- No `ingest_log` growth in `failed` or `skipped` beyond the recorded baseline.
+- A sync tick (`:07/:22/:37/:52`) mirrors any new file to Dropbox.
+
+While you are here, **record the exact log strings** for a non-zero ingest exit and for supercronic's "falling behind" warning — those literal strings are what the weekly log scan in [section 7](#7-weekly-monitoring) greps for.
+
+```bash
+# 4. Reboot test, against the final configuration
+sudo reboot
+# ... then, after it comes back:
+docker compose -f deploy/docker-compose.yml ps        # both services up
+docker compose -f deploy/docker-compose.yml logs --since 20m scheduler
+```
+
+**Pass:** both services return without human intervention and a scheduled tick fires. See [section 7](#7-weekly-monitoring) about the one expected failed tick immediately after a reboot.
+
+---
+
+## 6. Cutover from the dev machine (one-time)
+
+Moves the existing receipt corpus — database rows *and* the rendered PDF tree — from the dev machine's native PostgreSQL 18 (port 5435, database `receipt_index`) to the server. Run it as Gate E, with the scheduler still down.
+
+`ingest_log` is **load-bearing data, not "just a log"**: idempotency is the union of `receipts.source_id` and `ingest_log.source_id`. If only `receipts` made it across, every historically skipped or failed item would be reprocessed — LLM spend, and previously-skipped items may now insert under model drift.
+
+No sequence resync is needed: there are no sequences, `serial`, or identity columns in either schema (UUID v7 defaults throughout).
+
+### 6.1 Preconditions
+
+- [ ] **The server database is empty.** If Gates B–D touched it (they do: `make migrate-up` creates the migration tables), drop and recreate before restoring — `pg_restore` into a schema that already exists collides on everything.
+- [ ] **Proven, not assumed:** immediately before the drop, the server's `ingest_log` has **zero rows** (see 6.3). "The scheduler was never up" is a claim; zero rows is evidence.
+- [ ] **The rsync target is empty.** `find data/receipts -type f | wc -l` on the server returns `0`. An additive rsync over leftovers strands orphan PDFs: filenames embed the LLM-extracted vendor, and extraction is not deterministic enough for names to collide cleanly.
+- [ ] Gates A–D have passed.
+
+### 6.2 Enforce the laptop stop
+
+Not a habit — a lock. Rename the laptop's config so an absent-minded `receipt-index ingest` cannot connect to anything:
+
+```bash
+cd /path/to/receipt-index   # your laptop clone
+mv .env .env.retired-$(date +%Y%m%d)
+mv receipt-index.yaml receipt-index.yaml.retired-$(date +%Y%m%d)
+```
+
+Take the dump **strictly after** the last laptop run has completed.
+
+Capture the source-of-truth number *from the source*, at dump time:
+
+```bash
+psql "postgresql://receipt_index@localhost:5435/receipt_index" -At -c "
+    SELECT count(*) FROM (
+        SELECT source_id FROM receipt.receipts
+        UNION
+        SELECT source_id FROM receipt.ingest_log
+    ) AS known;"
+```
+
+Write that number down. It is the single strongest cutover check.
+
+### 6.3 Dump
+
+```bash
+pg_dump --format=custom --no-password \
+    --file=~/receipt-index-cutover-$(date +%Y%m%d).dump \
+    "postgresql://receipt_index@localhost:5435/receipt_index"
+```
+
+**Retain this file. It is *the* rollback artifact.** If the cutover is aborted, re-restore from this same dump — never take a second dump (by then the laptop database may have drifted, and a fresh dump would launder the very state you are rolling back from).
+
+Copy it to the server:
+
+```bash
+scp ~/receipt-index-cutover-*.dump receipt-server:~/
+```
+
+On the server, prove emptiness, then drop and recreate:
+
+```bash
+cd ~/receipt-index
+
+# Evidence of "paused": both must be 0
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler -c '
+    psql "$DATABASE_URL" -c "SELECT
+        (SELECT count(*) FROM receipt.receipts)   AS receipts,
+        (SELECT count(*) FROM receipt.ingest_log) AS ingest_log;"'
+
+# Fresh, empty, owned by the app role.
+# db-init only runs on first boot of an empty volume, so the database-level
+# bits it applied must be re-applied by hand here. The roles are cluster-level
+# and survive a DROP DATABASE.
+docker compose -f deploy/docker-compose.yml exec db sh -c '
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres -c "DROP DATABASE $POSTGRES_DB;"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres -c "CREATE DATABASE $POSTGRES_DB OWNER receipt_index;"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -c "
+        GRANT CONNECT ON DATABASE $POSTGRES_DB TO receipt_index_dev_all, receipt_index_dev_write, receipt_index_dev_read;
+        ALTER SCHEMA public OWNER TO receipt_index;"'
+```
+
+### 6.4 Restore
+
+```bash
+docker compose -f deploy/docker-compose.yml cp \
+    ~/receipt-index-cutover-<date>.dump db:/tmp/cutover.dump
+
+docker compose -f deploy/docker-compose.yml exec db sh -c '
+    pg_restore --exit-on-error --verbose \
+        --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" /tmp/cutover.dump'
+```
+
+**Without `--no-owner` and without `--no-acl`** — both omissions are deliberate:
+
+- `--no-owner` would leave every object owned by the superuser, and the application (connecting as `receipt_index`) would be running on objects it does not own. The dump's `ALTER ... OWNER TO receipt_index` statements succeed precisely because `db-init` pre-created that role.
+- `--no-acl` would drop the column-level grants the migrations issue; the only ACLs in the dump target the three `receipt_index_dev_*` roles, which exist.
+
+The dump also carries the `pg_trgm` extension and **both** `schema_migrations_*` tables at their source versions (public `1`, receipt `7` as of 2026-08-01), which is what makes the next step a no-op rather than a re-run.
+
+```bash
+make migrate-up
+```
+
+**Expect "no change".** If it applies anything, that is a genuine post-v7 migration added in the repo since the laptop last migrated — which is the correct ordering for it to be applied in.
+
+Re-run the Gate C queries: same expected versions, `dirty = f`.
+
+### 6.5 Files
+
+```bash
+# On the laptop — -c compares by checksum, not size+mtime
+rsync -av -c --info=progress2 \
+    /path/to/receipt-index/data/receipts/ \
+    receipt-server:receipt-index/data/receipts/
+
+# Counts must match
+find /path/to/receipt-index/data/receipts -type f | wc -l   # laptop
+ssh receipt-server 'find ~/receipt-index/data/receipts -type f | wc -l'             # server
+```
+
+Then on the server:
+
+```bash
+chown -R 1000:1000 data/receipts      # sudo if not your uid
+```
+
+The database stores paths **relative to the store root**, so the tree transplants with no database rewriting.
+
+### 6.6 Verification queries
+
+Run these **as the app role over the app DSN** — that is, inside the container, using `$DATABASE_URL`. Running them as the superuser would pass even when the application is locked out by ownership or grants, which is the exact failure class these are here to catch.
+
+```bash
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler -c 'psql "$DATABASE_URL"'
+```
+
+**1. Distinct `source_id` union — the strongest single number.** Must equal the value captured in 6.2:
+
+```sql
+SELECT count(*) FROM (
+    SELECT source_id FROM receipt.receipts
+    UNION
+    SELECT source_id FROM receipt.ingest_log
+) AS known;
+```
+
+**2. Per-table counts** — compare against the laptop:
+
+```sql
+SELECT 'receipts' AS relation, count(*) FROM receipt.receipts
+UNION ALL
+SELECT 'ingest_log', count(*) FROM receipt.ingest_log;
+```
+
+**3. Per-status `ingest_log` breakdown — RECORD THIS. It is the monitoring baseline** for [section 7](#7-weekly-monitoring):
+
+```sql
+SELECT status, count(*) FROM receipt.ingest_log GROUP BY status ORDER BY status;
+```
+
+> `receipts` ≫ `ingest_log` is **expected**, not a defect: receipts ingested before the dead-letter log existed have no log rows at all. Do not "fix" it.
+
+**4. Schema integrity** — a partially-errored restore can leave the counts right and the indexes silently missing:
+
+```sql
+SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_trgm';
+
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'receipt' AND indexname = 'idx_receipts_vendor';
+```
+
+Both must return exactly one row (`idx_receipts_vendor` is the GIN trigram index on `vendor` that every `search --vendor` depends on).
+
+**5. Referential file check** — every `pdf_path` resolves to a real file. Run it in the container, where the store is mounted:
+
+```bash
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler -c '
+    psql "$DATABASE_URL" -At -c "SELECT pdf_path FROM receipt.receipts" \
+    | while IFS= read -r p; do
+          [ -f "/app/data/receipts/$p" ] || echo "MISSING $p"
+      done | tee /tmp/missing.txt | wc -l'
+```
+
+**Must be `0`.** Orphans (files with no row) are counted separately and are tolerable:
+
+```bash
+docker compose -f deploy/docker-compose.yml run --rm --entrypoint sh scheduler -c '
+    psql "$DATABASE_URL" -At -c "SELECT pdf_path FROM receipt.receipts" | sort > /tmp/db.txt
+    ( cd /app/data/receipts && find . -type f | sed "s|^\./||" ) | sort > /tmp/fs.txt
+    echo "orphan files: $(comm -13 /tmp/db.txt /tmp/fs.txt | wc -l)"'
+```
+
+**6. First-cycle duplicate check** — run after Gate G's first automatic ticks. Duplicates cannot appear as double rows (`uq_receipts_source_id` forbids it); they appear as *fresh log rows for old items*. Substitute the cutover timestamp:
+
+```sql
+SELECT count(*)
+FROM receipt.ingest_log l
+JOIN receipt.receipts r ON r.source_id = l.source_id
+WHERE l.created_at > TIMESTAMPTZ '2026-08-01 00:00:00+00'   -- cutover mark
+  AND r.created_at < TIMESTAMPTZ '2026-08-01 00:00:00+00';
+```
+
+**Must be `0`.**
+
+**7. End-to-end, from the laptop** — a known historical receipt is searchable and viewable through the SSH wrapper (see [section 9](#9-searching-from-the-laptop)):
+
+```bash
+scripts/receipt-search search --vendor "Southern California Edison"
+scripts/receipt-search show <one-of-those-ids>
+```
+
+### 6.7 Finish
+
+Proceed to Gate F (Dropbox bulk mirror, count-verified) and only then Gate G. Do not start the scheduler earlier: bringing it up activates *all four* cron lines at once — ingest, both mirrors, and the nightly backup. If you need the scheduler running with the mirror still off, comment out the two `rclone` lines in `deploy/crontab` locally (leave the edit uncommitted) and restore them after Gate F.
+
+### 6.8 Abort criterion
+
+**The point of no return is the first server cycle that ingests genuinely new mail.**
+
+Before that point — rollback:
+
+```bash
+docker compose -f deploy/docker-compose.yml stop scheduler
+# drop + recreate the database exactly as in 6.3, then re-restore
+# from the SAME retained dump file (6.4). Never take a fresh dump.
+```
+
+Then restore the laptop's `.env` / `receipt-index.yaml` from their `.retired-*` names.
+
+After that point, the laptop database is stale: recovery is a *reverse cutover* (dump the server, restore to the laptop), not a rollback. The Dropbox mirror is additive and needs no unwinding in either case.
+
+### 6.9 Retiring the dev PostgreSQL
+
+Keep the dev cluster's `receipt_index` database until the server has earned it. Explicit criterion — **7 consecutive days** of:
+
+- zero growth in `failed` and `skipped` `ingest_log` counts beyond the baseline,
+- no supercronic falling-behind warnings,
+- Dropbox/server file-count parity holding.
+
+Then, and only then:
+
+```bash
+# The ONLY irreversible step in this plan. Take a final dump first.
+pg_dump --format=custom --file=~/receipt-index-final-$(date +%Y%m%d).dump \
+    "postgresql://receipt_index@localhost:5435/receipt_index"
+# Store it somewhere durable, verify it is non-empty, and only then:
+psql -p 5435 -c 'DROP DATABASE receipt_index;'
+```
+
+---
+
+## 7. Weekly monitoring
+
+Solo-operator routine. Five minutes, once a week.
+
+### 7.1 Per-status `ingest_log` breakdown vs. the recorded baseline
+
+The important one, and the reason it is not just `receipt-index failures`:
+
+**`receipt-index failures` filters `status = 'failed'` only.** A receipt the LLM scored below the confidence threshold is logged as **`skipped`**, the cycle exits **0**, nothing appears in `failures` — and the item is dead-lettered forever, because idempotency counts `ingest_log` rows regardless of status. That is the silent half of the data-loss surface, and it has real precedent in this project (the `amount: 0` saga; payment confirmations not recognized as receipts).
+
+```bash
+docker compose -f deploy/docker-compose.yml exec scheduler sh -c '
+    psql "$DATABASE_URL" -c "SELECT status, count(*) FROM receipt.ingest_log
+                             GROUP BY status ORDER BY status;"'
+```
+
+Compare all three numbers against the Gate E baseline. `success` growing is normal. **`skipped` or `failed` growing needs eyeballs:**
+
+```bash
+docker compose -f deploy/docker-compose.yml exec scheduler sh -c '
+    psql "$DATABASE_URL" -c "
+        SELECT created_at, source_type, source_id, email_sender, email_subject, error_message
+        FROM receipt.ingest_log
+        WHERE status = '\''skipped'\''
+          AND created_at > NOW() - INTERVAL '\''8 days'\''
+        ORDER BY created_at DESC;"'
+```
+
+Read the senders and subjects. A genuine non-receipt is fine. A real receipt in that list means the extraction threshold or prompt needs work — and recovering it requires deleting its `ingest_log` row (see [section 8.2](#82-dlq-recovery)).
+
+Swap `'skipped'` for `'failed'` for the failure side, where `error_message` is populated.
+
+*Future work:* a `receipt-index failures --status skipped` flag, so this stops being a raw SQL step.
+
+### 7.2 Log scan
+
+```bash
+docker compose -f deploy/docker-compose.yml logs --since 168h scheduler \
+    | grep -Ei 'level=error|job failed|behind|Traceback'
+```
+
+Grep for the exact strings recorded during Gate G; the pattern above is the broad net.
+
+Two things to know:
+
+- **One failed ingest tick immediately after every reboot is expected.** Container restart policies do not honour `depends_on` health ordering, so the scheduler can fire its first tick while Postgres is still starting. The run aborts on connection failure *before* any item is processed, so it writes no `ingest_log` rows and dead-letters nothing; the next tick self-heals. A *second* consecutive failure is not expected.
+- **Falling-behind warnings** mean a cycle outran its 15-minute interval. supercronic's no-overlap guarantee holds (it will not start an overlapping run), so nothing is corrupted — but this is the early-warning signal for issue #36's O(N) mailbox enumeration, and the cue to revisit the cadence.
+
+### 7.3 Dropbox freshness
+
+From any device, no SSH: check the newest file under `receipt-index/receipts` in Dropbox. This is the free end-to-end delivery check — it exercises ingest, rendering, the store, and the mirror in one look.
+
+Read it correctly: a fresh file **confirms** delivery. The *absence* of new files is not a health signal, because it is the normal state during a quiet week. Only chase it when you know receipts arrived in the window.
+
+Also glance at `receipt-index/backups`: seven files, day-of-week names, the newest dated last night.
+
+### 7.4 Disk
+
+```bash
+df -h /
+du -sh ~/receipt-index/data/*
+```
+
+Container logs are capped (10 MB × 7 files per service) and the backup directory is bounded at seven dumps by day-of-week rotation, so growth should be dominated by the receipt tree and pgdata.
+
+### 7.5 Future work
+
+A dead-man's-snitch (healthchecks.io-style) ping as a fourth crontab line after each successful cycle. Absence-of-ping covers crash-loop, falling-behind, and config breakage in one mechanism — and unlike everything above, it pages *you* instead of waiting to be checked.
+
+---
+
+## 8. Routine operations
+
+### 8.1 Upgrade
+
+```bash
+cd ~/receipt-index
+git pull
+docker compose -f deploy/docker-compose.yml build
+
+# Stop the scheduler BEFORE `up -d` recreates it.
+# Recreation kills the container; a cycle interrupted between writing a PDF and
+# committing its row leaves an orphan file behind. Check for an in-flight cycle
+# first — ticks land on :00/:15/:30/:45 and normally finish in well under a
+# minute, so there is a wide idle window.
+docker compose -f deploy/docker-compose.yml exec scheduler pgrep -af 'receipt-index ingest' || echo "idle"
+docker compose -f deploy/docker-compose.yml stop scheduler
+
+# Migrations before the new code runs (the db service stays up throughout)
+make migrate-up
+
+docker compose -f deploy/docker-compose.yml up -d
+docker compose -f deploy/docker-compose.yml logs -f scheduler
+```
+
+Rebuild the image on **every** `playwright` version bump — the browser build is pinned per Playwright release, and a mismatch between the pip package and the baked browser breaks HTML rendering (and therefore dead-letters receipts).
+
+After an upgrade that touched the renderer, the Dockerfile, or the config, re-run Gates A–D before walking away.
+
+### 8.2 DLQ recovery
+
+Dead-lettering is permanent by design: a `source_id` present in `ingest_log` is never looked at again, whatever its status. Recovery is deleting the log row so the item becomes unknown again.
+
+Only worth doing for **environmental** causes — a rendering gap, a permissions problem, a network blip, a corrupted credential. Content failures (the LLM genuinely cannot read the document) will simply fail again, and re-running them costs Anthropic spend for nothing.
+
+1. **Fix the cause first.** Re-run the relevant gate to prove it.
+
+2. **Check for an orphaned PDF for that `source_id`.** A failure between rendering and the database write leaves a file with no row; leaving it behind means a duplicate PDF after the retry succeeds:
+
+   ```bash
+   docker compose -f deploy/docker-compose.yml exec scheduler sh -c '
+       psql "$DATABASE_URL" -c "
+           SELECT source_id, email_subject, error_message, created_at
+           FROM receipt.ingest_log WHERE status = '\''failed'\''
+           ORDER BY created_at DESC;"'
+   # then look for a plausibly-matching file under the vendor/date path:
+   ls -l data/receipts/<YYYY>/<MM>/
+   ```
+
+3. **Delete the log rows to force a retry.** Scope it — never `DELETE FROM receipt.ingest_log WHERE status = 'failed'` wholesale, which would also resurrect genuine content failures:
+
+   ```sql
+   -- Preview first
+   SELECT source_id, email_subject, error_message
+   FROM receipt.ingest_log
+   WHERE status = 'failed'
+     AND created_at >= TIMESTAMPTZ '2026-08-01 00:00:00+00'
+     AND error_message LIKE '%<the environmental error substring>%';
+
+   -- Then delete exactly those
+   DELETE FROM receipt.ingest_log
+   WHERE status = 'failed'
+     AND created_at >= TIMESTAMPTZ '2026-08-01 00:00:00+00'
+     AND error_message LIKE '%<the environmental error substring>%';
+   ```
+
+   The same applies to `status = 'skipped'` rows for receipts that should have been recognized.
+
+4. The next scheduled cycle picks them up. Watch it, then re-check the per-status breakdown.
+
+### 8.3 Disaster recovery from Dropbox
+
+The full-loss story: the server is gone and Dropbox holds everything — the nightly dumps under `receipt-index/backups` and the complete receipt tree under `receipt-index/receipts`.
+
+1. Rebuild the host per [section 2](#2-server-prerequisites), then provision per [section 3](#3-provisioning) (clone, `.env` from 1Password, directories with uid 1000, rclone config).
+
+2. `docker compose -f deploy/docker-compose.yml build && docker compose -f deploy/docker-compose.yml up -d db`. First boot of the empty volume runs `db-init`, creating the `receipt_index` owner role and the grant-target roles — this must happen **before** the restore, or the dump's `OWNER TO` statements fail and the app is locked out.
+
+3. Pull both trees back:
+
+   ```bash
+   docker compose -f deploy/docker-compose.yml run --rm --entrypoint rclone scheduler \
+       copy dropbox:receipt-index/backups /app/data/backups \
+       --config /app/.rclone/rclone.conf -v
+
+   docker compose -f deploy/docker-compose.yml run --rm --entrypoint rclone scheduler \
+       copy dropbox:receipt-index/receipts /app/data/receipts \
+       --config /app/.rclone/rclone.conf -v
+
+   ls -l data/backups/          # pick the newest receipt_index-<dow>.dump
+   chown -R 1000:1000 data      # sudo if not your uid
+   ```
+
+4. Restore into the fresh, empty database — again **without** `--no-owner` and **without** `--no-acl`:
+
+   ```bash
+   docker compose -f deploy/docker-compose.yml cp \
+       data/backups/receipt_index-<dow>.dump db:/tmp/restore.dump
+   docker compose -f deploy/docker-compose.yml exec db sh -c '
+       pg_restore --exit-on-error --verbose \
+           --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" /tmp/restore.dump'
+   make migrate-up      # no-op, or applies a delta newer than the dump
+   ```
+
+5. Re-run Gates A–D and the verification queries in [6.6](#66-verification-queries), then Gate G. Expect to lose at most one day of ingest (the window between the last nightly dump and the loss); those messages are still in the mailbox and will be re-ingested on the next cycles, since their `source_id`s went down with the database.
+
+---
+
+## 9. Searching from the laptop
+
+`scripts/receipt-search` runs the CLI inside the server's scheduler container over SSH and passes every argument straight through:
+
+```bash
+scripts/receipt-search search --vendor "Acme Parking (U.S.), LLC"
+scripts/receipt-search search --date-from 2026-01-01 --date-to 2026-03-31 --output json
+scripts/receipt-search show 019537f1-...-a3
+scripts/receipt-search failures
+scripts/receipt-search --help
+```
+
+Symlink it onto your `PATH` if you use it often:
+
+```bash
+ln -s /path/to/receipt-index/scripts/receipt-search ~/bin/receipt-search
+```
+
+Environment overrides:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RECEIPT_INDEX_SSH_HOST` | `receipt-server` | SSH target (hostname or `~/.ssh/config` alias) |
+| `RECEIPT_INDEX_COMPOSE_PROJECT` | `receipt-index` | Compose project name |
+| `RECEIPT_INDEX_SERVICE` | `scheduler` | Service to exec into |
+
+Two details worth knowing when it misbehaves:
+
+- It targets the container by **compose project name** (`docker compose -p receipt-index exec`), not by compose-file path, so it does not care where the repo was cloned on the server. The price is that the project must be **up** — which is the normal state under `restart: unless-stopped`. `no such service: scheduler` means the service is down; SSH in and check `docker compose -f deploy/docker-compose.yml ps`.
+- Arguments are re-quoted client-side before being handed to SSH, because SSH flattens its argument list into a single string that the remote shell re-parses. That is what keeps `--vendor "Acme Parking (U.S.), LLC"` intact as one argument.
+
+Anything the CLI can do is available this way, including `ingest`, but leave scheduled ingest to supercronic — a manual run that overlaps a scheduled tick is not protected by the no-overlap guarantee (which is per cron line, inside the scheduler).

--- a/scripts/receipt-search
+++ b/scripts/receipt-search
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Run the receipt-index CLI on the always-on server from this laptop.
+#
+#     scripts/receipt-search search --vendor "Acme Parking (U.S.), LLC"
+#     scripts/receipt-search show <receipt-id>
+#     scripts/receipt-search failures --output json
+#
+# Everything after the script name is passed through to `receipt-index` inside
+# the running scheduler container. See docs/user/server-deployment.md.
+#
+# Two things here are load-bearing:
+#
+#   * printf %q re-quoting. ssh does not pass an argv to the remote host; it
+#     concatenates its arguments with spaces and hands the result to the remote
+#     login shell, which word-splits it again. Vendor filters routinely contain
+#     spaces, parentheses and commas ("Acme Parking (U.S.), LLC"), so each
+#     argument is re-quoted for that second parse. %q emits backslash escapes,
+#     which every POSIX shell understands; it only reaches for bash's $'...'
+#     form on control characters, which cannot appear in a search filter.
+#
+#   * -T. ssh allocates no TTY for a command invocation, so `docker compose
+#     exec` must be told not to ask for one; without it exec fails outright.
+#
+# Container targeting is by compose *project name* (-p), not by compose-file
+# path (-f). The project name is set in deploy/docker-compose.yml (`name:
+# receipt-index`) and is therefore independent of where the repo was cloned on
+# the server, which -f is not. The tradeoff: -p can only find a project that is
+# already up. That is the normal state — the scheduler runs under `restart:
+# unless-stopped` — and a "no such service" error correctly means the service
+# is down, which is worth surfacing rather than papering over.
+
+set -euo pipefail
+
+# Default assumes a `receipt-server` alias in ~/.ssh/config; override with
+# RECEIPT_INDEX_SSH_HOST or edit the alias to point at your server.
+SSH_HOST="${RECEIPT_INDEX_SSH_HOST:-receipt-server}"
+COMPOSE_PROJECT="${RECEIPT_INDEX_COMPOSE_PROJECT:-receipt-index}"
+SERVICE="${RECEIPT_INDEX_SERVICE:-scheduler}"
+
+# With no arguments, `printf '%q '` would emit a quoted empty string and the
+# CLI would reject it as an unknown command. Show the CLI's own help instead.
+if [ "$#" -eq 0 ]; then
+    set -- --help
+fi
+
+remote_args="$(printf '%q ' "$@")"
+
+exec ssh "${SSH_HOST}" "docker compose -p $(printf '%q' "${COMPOSE_PROJECT}") \
+exec -T $(printf '%q' "${SERVICE}") receipt-index ${remote_args}"

--- a/src/receipt_index/cli.py
+++ b/src/receipt_index/cli.py
@@ -25,6 +25,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+# Third-party loggers that emit per-page/per-glyph records at DEBUG/INFO and
+# drown out application logs (notably in container output).
+_NOISY_LIBRARY_LOGGERS = ("pdfminer", "fontTools", "PIL")
+
+
+def _configure_logging(config: AppConfig) -> None:
+    """Configure application logging and quiet noisy third-party libraries.
+
+    The noisy library loggers are always clamped to WARNING, even when the
+    application level is DEBUG. Debugging those libraries requires raising
+    their level explicitly.
+
+    Args:
+        config: Loaded application configuration.
+    """
+    # force=True: reconfigure deterministically even if a handler was already
+    # installed on the root logger (e.g. by an embedding process or test runner).
+    logging.basicConfig(
+        level=getattr(logging, config.logging.level, logging.INFO),
+        format=_LOG_FORMAT,
+        force=True,
+    )
+    for name in _NOISY_LIBRARY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
 
 def _load_config_or_exit(ctx: click.Context) -> AppConfig:
     """Load AppConfig from Click context, exiting with a clear message on error."""
@@ -78,11 +105,7 @@ def ingest(
 
     config = _load_config_or_exit(ctx)
 
-    # Configure logging from config
-    logging.basicConfig(
-        level=getattr(logging, config.logging.level, logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    _configure_logging(config)
 
     # Filter sources if --source is specified
     sources = config.sources
@@ -216,10 +239,7 @@ def search(
 
     config = _load_config_or_exit(ctx)
 
-    logging.basicConfig(
-        level=getattr(logging, config.logging.level, logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    _configure_logging(config)
 
     if amount is not None and (amount_min is not None or amount_max is not None):
         raise click.UsageError(
@@ -289,10 +309,7 @@ def failures(ctx: click.Context, output_format: str) -> None:
 
     config = _load_config_or_exit(ctx)
 
-    logging.basicConfig(
-        level=getattr(logging, config.logging.level, logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    _configure_logging(config)
 
     with get_connection(config.database.url) as conn:
         results = get_ingest_failures(conn)
@@ -334,10 +351,7 @@ def show(ctx: click.Context, receipt_id: str, output_format: str) -> None:
 
     config = _load_config_or_exit(ctx)
 
-    logging.basicConfig(
-        level=getattr(logging, config.logging.level, logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    _configure_logging(config)
 
     try:
         uid = UUID(receipt_id)

--- a/src/receipt_index/renderer.py
+++ b/src/receipt_index/renderer.py
@@ -1,4 +1,12 @@
-"""Receipt-to-PDF rendering."""
+"""Receipt-to-PDF rendering.
+
+Receipt HTML is untrusted third-party content rendered unattended, so both
+rendering engines run with network egress blocked: only inline resources
+(``data:`` URIs embedded in the document) are served and every remote
+reference is refused. This removes the exfiltration path a renderer exploit
+would need, and makes PDFs deterministic — no remote images or trackers are
+fetched at render time.
+"""
 
 from __future__ import annotations
 
@@ -7,12 +15,24 @@ import html
 import logging
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
+    from playwright.sync_api import Route
+
     from receipt_index.models import Attachment, RawReceipt
 
 logger = logging.getLogger(__name__)
+
+#: URL schemes whose payload travels with the document — fetching them causes
+#: no network or filesystem I/O. Everything else (http, https, file, ftp,
+#: protocol-relative and relative references) counts as remote.
+INLINE_URL_SCHEMES = frozenset({"data", "about", "blob"})
+
+
+class RemoteResourceBlockedError(Exception):
+    """Raised when a render attempts to fetch a non-inline resource."""
 
 
 PLAIN_TEXT_TEMPLATE = """\
@@ -168,8 +188,71 @@ def _html_to_pdf_bytes(html_content: str) -> bytes:
     return _html_to_pdf_weasyprint(html_content)
 
 
+def _is_inline_url(url: str) -> bool:
+    """Report whether a URL can be served without leaving the render process.
+
+    Args:
+        url: URL a rendering engine is about to fetch.
+
+    Returns:
+        True for inline schemes (see :data:`INLINE_URL_SCHEMES`), False for
+        every remote or ambiguous reference.
+    """
+    return urlsplit(url).scheme.lower() in INLINE_URL_SCHEMES
+
+
+def _block_remote_requests(route: Route) -> None:
+    """Playwright route handler that aborts every non-inline request.
+
+    Aborting rather than stalling matters: a blocked resource fails
+    immediately, so the page finishes rendering instead of waiting out a
+    network timeout.
+
+    Args:
+        route: Intercepted Playwright route for a request made by the page.
+    """
+    url = route.request.url
+    if _is_inline_url(url):
+        route.continue_()
+        return
+    logger.debug("Blocked remote request during render: %s", url)
+    route.abort()
+
+
+def _inline_only_url_fetcher(url: str) -> Any:
+    """Serve inline URLs for weasyprint and refuse remote ones.
+
+    Args:
+        url: URL weasyprint wants to fetch.
+
+    Returns:
+        A weasyprint URL fetcher response for inline URLs.
+
+    Raises:
+        RemoteResourceBlockedError: If the URL is not inline. weasyprint
+            converts fetcher exceptions into a non-fatal ``URLFetchingError``,
+            so the render continues with the resource missing.
+    """
+    if not _is_inline_url(url):
+        logger.debug("Blocked remote resource during render: %s", url)
+        raise RemoteResourceBlockedError(f"Remote resource blocked: {url}")
+
+    try:
+        from weasyprint.urls import URLFetcher
+    except ImportError:  # weasyprint < 68
+        from weasyprint.urls import default_url_fetcher
+
+        return default_url_fetcher(url)
+
+    return URLFetcher(allowed_protocols=INLINE_URL_SCHEMES).fetch(url)
+
+
 def _html_to_pdf_playwright(html_content: str) -> bytes:
-    """Convert HTML string to PDF bytes via Playwright headless Chromium."""
+    """Convert HTML string to PDF bytes via Playwright headless Chromium.
+
+    Every request the document makes is intercepted; non-inline requests are
+    aborted before they reach the network.
+    """
     from playwright.sync_api import sync_playwright
 
     # Ensure PLAYWRIGHT_BROWSERS_PATH is set for local installs
@@ -179,7 +262,12 @@ def _html_to_pdf_playwright(html_content: str) -> bytes:
     with sync_playwright() as p:
         browser = p.chromium.launch()
         try:
-            page = browser.new_page()
+            # JS off: email HTML never legitimately needs scripts (mail clients
+            # do not run them), and route() cannot intercept WebSockets that
+            # script could open — disabling JS closes that egress gap outright.
+            context = browser.new_context(java_script_enabled=False)
+            context.route("**/*", _block_remote_requests)
+            page = context.new_page()
             page.set_content(html_content, wait_until="domcontentloaded")
             pdf_bytes: bytes = page.pdf(format="Letter")
             return pdf_bytes
@@ -188,8 +276,12 @@ def _html_to_pdf_playwright(html_content: str) -> bytes:
 
 
 def _html_to_pdf_weasyprint(html_content: str) -> bytes:
-    """Convert HTML string to PDF bytes via weasyprint."""
+    """Convert HTML string to PDF bytes via weasyprint.
+
+    Uses an inline-only URL fetcher so remote references are refused rather
+    than fetched, matching the Playwright path.
+    """
     import weasyprint
 
-    doc = weasyprint.HTML(string=html_content)
+    doc = weasyprint.HTML(string=html_content, url_fetcher=_inline_only_url_fetcher)
     return doc.write_pdf()  # type: ignore[no-any-return]

--- a/tests/integration/test_docker_render.py
+++ b/tests/integration/test_docker_render.py
@@ -1,0 +1,209 @@
+"""In-container checks for the production image.
+
+These tests exercise the image built from ``Dockerfile`` rather than the host
+environment. They are the load-bearing proof for the deployment: a rendering
+gap in the container silently DLQs receipts (``ingest_log``), and DLQ'd items
+are never retried, so both render engines and the scheduler/mirror/backup
+binaries must be verified inside the image before it goes unattended.
+
+The image is not built here (too slow). Point ``RECEIPT_INDEX_IMAGE`` at a
+pre-built tag, or build the default ``receipt-index:latest`` first::
+
+    docker build -t receipt-index:latest .
+    make test-integration
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+IMAGE = os.environ.get("RECEIPT_INDEX_IMAGE", "receipt-index:latest")
+
+# Cold-start Chromium in a container is slow; a render smoke test is still
+# far below this ceiling.
+_TIMEOUT_SECONDS = 180
+
+
+def _image_available() -> bool:
+    """Return True if the docker CLI works and the target image exists."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", IMAGE],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _image_available(),
+        reason=(
+            f"docker unavailable or image {IMAGE!r} not built "
+            "(build it, or set RECEIPT_INDEX_IMAGE)"
+        ),
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _truncate_receipts() -> None:
+    """Override the package-level DB fixture; these tests need no database."""
+
+
+def _docker_run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the image with an overridden entrypoint and capture its output.
+
+    ``--shm-size=1g`` mirrors the production compose setting: Chromium
+    crashes on the 64 MB default ``/dev/shm``.
+    """
+    return subprocess.run(
+        ["docker", "run", "--rm", "--shm-size=1g", *args],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_SECONDS,
+        check=False,
+    )
+
+
+def _run_python(script: str) -> str:
+    """Run a Python snippet inside the image, returning its stdout.
+
+    Fails the test with the container's stderr if the snippet exits non-zero.
+    """
+    result = _docker_run("--entrypoint", "python", IMAGE, "-c", script)
+    assert result.returncode == 0, (
+        f"python snippet failed in {IMAGE} (exit {result.returncode})\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    return result.stdout.strip()
+
+
+# The renderer's private engine functions are called directly on purpose: the
+# public path (`_html_to_pdf_bytes`) falls back from Playwright to weasyprint,
+# which would mask exactly the failure these tests exist to catch.
+
+_PLAYWRIGHT_SCRIPT = """
+import os
+
+from receipt_index.renderer import _html_to_pdf_playwright
+
+assert os.getuid() == 1000, f"expected uid 1000, got {os.getuid()}"
+
+html = (
+    "<html><body><h1>ACME Hardware</h1>"
+    "<table>"
+    "<tr><td>Widget</td><td style='text-align:right'>$42.99</td></tr>"
+    "<tr><td><strong>Total</strong></td><td><strong>$42.99</strong></td></tr>"
+    "</table></body></html>"
+)
+pdf = _html_to_pdf_playwright(html)
+assert pdf[:5] == b"%PDF-", repr(pdf[:20])
+print(len(pdf))
+"""
+
+_WEASYPRINT_SCRIPT = """
+import os
+from datetime import UTC, datetime
+
+from receipt_index.models import RawReceipt
+from receipt_index.renderer import render_pdf
+
+assert os.getuid() == 1000, f"expected uid 1000, got {os.getuid()}"
+
+raw = RawReceipt(
+    source_id="docker-smoke-1",
+    source_name="smoke",
+    source_type="imap",
+    date=datetime(2026, 8, 1, 12, 0, tzinfo=UTC),
+    subject="Your receipt",
+    sender="billing@example.com",
+    text_body="Total: $42.99\\nThank you for your business.",
+)
+pdf = render_pdf(raw)
+assert pdf[:5] == b"%PDF-", repr(pdf[:20])
+print(len(pdf))
+"""
+
+_BROWSERS_PATH_SCRIPT = """
+import os
+
+from receipt_index.renderer import _html_to_pdf_playwright
+
+path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+assert path == "/ms-playwright", f"unexpected browsers path: {path!r}"
+
+entries = sorted(os.listdir(path))
+assert any(e.startswith("chromium") for e in entries), entries
+
+pdf = _html_to_pdf_playwright("<html><body><p>baked</p></body></html>")
+assert pdf[:5] == b"%PDF-", repr(pdf[:20])
+print(" ".join(entries))
+"""
+
+
+class TestInContainerRendering:
+    """Both render engines must work inside the image as uid 1000."""
+
+    def test_playwright_renders_html_receipt(self) -> None:
+        """Chromium renders an HTML receipt body to a non-trivial PDF."""
+        size = int(_run_python(_PLAYWRIGHT_SCRIPT))
+        assert size > 1000
+
+    def test_weasyprint_renders_text_receipt(self) -> None:
+        """The text path renders via weasyprint, proving the pango libs."""
+        size = int(_run_python(_WEASYPRINT_SCRIPT))
+        assert size > 500
+
+    def test_browsers_path_is_baked_into_the_image(self) -> None:
+        """Rendering works without the host supplying the browsers path.
+
+        No ``-e`` flag is passed to ``docker run``, so the container must find
+        Chromium under the image's own baked ``PLAYWRIGHT_BROWSERS_PATH``
+        (``/ms-playwright``). Host-env leakage via ``docker run`` is impossible
+        by construction; the compose-level ``env_file`` override is the real
+        leak vector and is prevented by the explicit ``environment:`` entry in
+        ``deploy/docker-compose.yml``.
+        """
+        entries = _run_python(_BROWSERS_PATH_SCRIPT).split()
+
+        assert any(entry.startswith("chromium") for entry in entries), entries
+
+
+class TestBundledBinaries:
+    """Scheduler, mirror, and backup binaries ship in the image."""
+
+    @pytest.mark.parametrize(
+        ("entrypoint", "args"),
+        [
+            ("supercronic", ["-version"]),
+            ("rclone", ["version"]),
+            ("pg_dump", ["--version"]),
+        ],
+    )
+    def test_binary_runs(self, entrypoint: str, args: list[str]) -> None:
+        """Each pinned binary is on PATH and executable as uid 1000."""
+        result = _docker_run("--entrypoint", entrypoint, IMAGE, *args)
+
+        assert result.returncode == 0, (
+            f"{entrypoint} failed (exit {result.returncode})\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert result.stdout.strip()
+
+    def test_pg_dump_is_version_18(self) -> None:
+        """pg_dump must be v18: an older client cannot dump the v18 server."""
+        result = _docker_run("--entrypoint", "pg_dump", IMAGE, "--version")
+
+        assert result.returncode == 0, result.stderr
+        assert "(PostgreSQL) 18." in result.stdout, result.stdout

--- a/tests/integration/test_pdf_extraction.py
+++ b/tests/integration/test_pdf_extraction.py
@@ -7,7 +7,7 @@ import os
 import pytest
 import weasyprint
 
-from receipt_index.pdf_reader import extract_text
+from receipt_index.pdf_reader import create_vision_agent, extract_text
 
 
 class TestPdfTextExtraction:
@@ -70,7 +70,8 @@ class TestPdfVisionFallback:
         """
         pdf_bytes = weasyprint.HTML(string=html).write_pdf()
 
-        result = extract_text(pdf_bytes)
+        agent = create_vision_agent(api_key=os.environ["ANTHROPIC_API_KEY"])
+        result = extract_text(pdf_bytes, vision_agent=agent)
 
         # Vision should extract the text from the rendered image
         assert "75.00" in result or "75" in result

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import textwrap
+from collections.abc import Iterator  # noqa: TC003
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path  # noqa: TC003
@@ -15,7 +17,7 @@ import pytest
 from click.testing import CliRunner
 
 from receipt_index.cli import cli
-from receipt_index.config import AppConfig, ImapSourceConfig
+from receipt_index.config import AppConfig, ImapSourceConfig, LoggingConfig
 from receipt_index.models import IngestLogEntry, Receipt
 from receipt_index.pipeline import IngestResult
 
@@ -80,6 +82,40 @@ _MINIMAL_CONFIG_YAML = textwrap.dedent("""\
     logging:
       level: INFO
 """)
+
+
+_NOISY_LOGGERS = ("pdfminer", "fontTools", "PIL")
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+@pytest.fixture(autouse=True)
+def isolated_logging() -> Iterator[None]:
+    """Give every test an unconfigured root logger, restoring global state after.
+
+    Logger levels and handlers are process-global, and ``logging.basicConfig``
+    is a no-op once the root logger has handlers (pytest installs its own), so
+    the root logger is emptied for the duration of the test. Autouse because
+    ``_configure_logging`` runs ``basicConfig(force=True)`` on every CLI
+    invocation — any test driving a command mutates global logging state and
+    must have it restored, not just the logging-focused tests.
+    """
+    tracked = (*_NOISY_LOGGERS, "receipt_index")
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_root_level = root.level
+    saved_levels = {name: logging.getLogger(name).level for name in tracked}
+
+    root.handlers = []
+    root.setLevel(logging.WARNING)
+    for name in tracked:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+    try:
+        yield
+    finally:
+        root.handlers = saved_handlers
+        root.setLevel(saved_root_level)
+        for name, level in saved_levels.items():
+            logging.getLogger(name).setLevel(level)
 
 
 @pytest.fixture()
@@ -658,6 +694,98 @@ class TestShowCommand:
         )
         assert result.exit_code != 0
         assert "not found" in result.output
+
+
+class TestLoggingSetup:
+    """Tests for CLI logging configuration."""
+
+    @patch("receipt_index.repository.search_receipts", return_value=[])
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
+    def test_noisy_libraries_clamped_at_info(
+        self,
+        mock_load_config: MagicMock,
+        mock_conn: MagicMock,
+        mock_search: MagicMock,
+        config_file: Path,
+        isolated_logging: None,
+    ) -> None:
+        """At app level INFO, pdfminer/fontTools/PIL are held at WARNING."""
+        mock_load_config.return_value = _make_config()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config", str(config_file), "search"])
+        assert result.exit_code == 0, result.output
+        for name in _NOISY_LOGGERS:
+            assert logging.getLogger(name).getEffectiveLevel() == logging.WARNING
+
+    @patch("receipt_index.repository.search_receipts", return_value=[])
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
+    def test_noisy_libraries_clamped_at_debug(
+        self,
+        mock_load_config: MagicMock,
+        mock_conn: MagicMock,
+        mock_search: MagicMock,
+        config_file: Path,
+        isolated_logging: None,
+    ) -> None:
+        """At app level DEBUG, app loggers emit DEBUG but libraries stay quiet."""
+        config = _make_config().model_copy(
+            update={"logging": LoggingConfig(level="DEBUG")}
+        )
+        mock_load_config.return_value = config
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config", str(config_file), "search"])
+        assert result.exit_code == 0, result.output
+
+        assert logging.getLogger("receipt_index").getEffectiveLevel() == logging.DEBUG
+        assert (
+            logging.getLogger("receipt_index.pipeline").getEffectiveLevel()
+            == logging.DEBUG
+        )
+        for name in _NOISY_LOGGERS:
+            assert logging.getLogger(name).getEffectiveLevel() == logging.WARNING
+            assert not logging.getLogger(name).isEnabledFor(logging.INFO)
+
+    @patch("receipt_index.repository.search_receipts", return_value=[])
+    @patch("receipt_index.db.get_connection")
+    @patch("receipt_index.cli.load_config")
+    def test_app_logging_level_and_format_unchanged(
+        self,
+        mock_load_config: MagicMock,
+        mock_conn: MagicMock,
+        mock_search: MagicMock,
+        config_file: Path,
+        isolated_logging: None,
+    ) -> None:
+        """receipt_index.* loggers keep the configured level and log format."""
+        mock_load_config.return_value = _make_config()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--config", str(config_file), "search"])
+        assert result.exit_code == 0, result.output
+
+        app_logger = logging.getLogger("receipt_index")
+        assert app_logger.level == logging.NOTSET  # not clamped explicitly
+        assert app_logger.getEffectiveLevel() == logging.INFO
+
+        root = logging.getLogger()
+        assert root.level == logging.INFO
+        assert len(root.handlers) == 1
+        formatter = root.handlers[0].formatter
+        assert formatter is not None
+        record = logging.LogRecord(
+            name="receipt_index.pipeline",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="ingest complete",
+            args=None,
+            exc_info=None,
+        )
+        assert formatter.format(record).endswith(
+            "INFO receipt_index.pipeline: ingest complete"
+        )
+        assert formatter.format(record) == logging.Formatter(_LOG_FORMAT).format(record)
 
 
 class TestConfigOption:

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -4,21 +4,55 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
+import time
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from receipt_index.models import Attachment, RawReceipt
 from receipt_index.renderer import (
+    RemoteResourceBlockedError,
+    _block_remote_requests,
     _embed_inline_images,
     _find_pdf_attachment,
     _html_to_pdf_bytes,
+    _html_to_pdf_playwright,
     _html_to_pdf_weasyprint,
+    _inline_only_url_fetcher,
+    _is_inline_url,
     _render_drive_file,
     _render_text_to_pdf,
     render_pdf,
 )
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Route
+
+# A 1x1 transparent GIF, small enough to embed inline in test fixtures.
+INLINE_GIF_DATA_URI = (
+    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+)
+REMOTE_IMAGE_URL = "https://example.invalid/tracker.png"
+
+
+def _chromium_available() -> bool:
+    """Report whether Playwright Chromium can be launched in this environment."""
+    os.environ.setdefault("PLAYWRIGHT_BROWSERS_PATH", ".playwright")
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            browser.close()
+        return True
+    except Exception:
+        return False
+
+
+CHROMIUM_AVAILABLE = _chromium_available()
 
 
 class TestRenderPdf:
@@ -401,3 +435,199 @@ class TestRenderPdfDriveRouting:
         )
         result = render_pdf(raw)
         assert result == b"%PDF-converted"
+
+
+class TestIsInlineUrl:
+    """Tests for the shared inline/remote URL classifier."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            INLINE_GIF_DATA_URI,
+            "data:text/plain,hello",
+            "DATA:text/plain,hello",
+            "about:blank",
+            "blob:null/2b8f0e6a",
+        ],
+    )
+    def test_inline_urls_allowed(self, url: str) -> None:
+        assert _is_inline_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.invalid/x.png",
+            "http://example.invalid/x.png",
+            "file:///etc/passwd",
+            "ftp://example.invalid/x.png",
+            "//example.invalid/x.png",
+            "/local/x.png",
+            "x.png",
+            "",
+        ],
+    )
+    def test_remote_urls_refused(self, url: str) -> None:
+        assert _is_inline_url(url) is False
+
+
+class TestBlockRemoteRequests:
+    """Tests for the Playwright route handler."""
+
+    @staticmethod
+    def _route(url: str) -> MagicMock:
+        route = MagicMock()
+        route.request.url = url
+        return route
+
+    def test_remote_request_aborted(self) -> None:
+        route = self._route(REMOTE_IMAGE_URL)
+        _block_remote_requests(route)
+
+        route.abort.assert_called_once_with()
+        route.continue_.assert_not_called()
+
+    def test_file_url_aborted(self) -> None:
+        route = self._route("file:///etc/passwd")
+        _block_remote_requests(route)
+
+        route.abort.assert_called_once_with()
+
+    def test_inline_request_allowed(self) -> None:
+        route = self._route(INLINE_GIF_DATA_URI)
+        _block_remote_requests(route)
+
+        route.continue_.assert_called_once_with()
+        route.abort.assert_not_called()
+
+    def test_about_blank_allowed(self) -> None:
+        route = self._route("about:blank")
+        _block_remote_requests(route)
+
+        route.continue_.assert_called_once_with()
+        route.abort.assert_not_called()
+
+
+class TestInlineOnlyUrlFetcher:
+    """Tests for the weasyprint URL fetcher."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            REMOTE_IMAGE_URL,
+            "http://example.invalid/x.png",
+            "file:///etc/passwd",
+            "/local/x.png",
+        ],
+    )
+    def test_remote_url_refused(self, url: str) -> None:
+        with pytest.raises(RemoteResourceBlockedError, match="Remote resource blocked"):
+            _inline_only_url_fetcher(url)
+
+    def test_data_uri_served(self) -> None:
+        payload = b"inline-bytes"
+        b64 = base64.b64encode(payload).decode("ascii")
+        response = _inline_only_url_fetcher(
+            f"data:application/octet-stream;base64,{b64}"
+        )
+
+        assert response.read() == payload
+
+
+class TestWeasyprintEgressBlocking:
+    """Rendering with the weasyprint engine must not fetch remote resources."""
+
+    @pytest.fixture(autouse=True)
+    def _suppress_weasyprint_warnings(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.CRITICAL, logger="weasyprint")
+
+    def test_remote_image_blocked_render_succeeds(self) -> None:
+        html_content = (
+            f'<html><body><p>Total: $42.99</p><img src="{REMOTE_IMAGE_URL}">'
+            "</body></html>"
+        )
+        result = _html_to_pdf_weasyprint(html_content)
+
+        assert result[:5] == b"%PDF-"
+        assert len(result) > 500
+
+    def test_remote_stylesheet_blocked_render_succeeds(self) -> None:
+        html_content = (
+            '<html><head><link rel="stylesheet" '
+            'href="https://example.invalid/style.css"></head>'
+            "<body><p>Total: $42.99</p></body></html>"
+        )
+        result = _html_to_pdf_weasyprint(html_content)
+
+        assert result[:5] == b"%PDF-"
+
+    def test_fetcher_is_wired_into_render(self) -> None:
+        requested: list[str] = []
+
+        def spy(url: str) -> object:
+            requested.append(url)
+            # Call the module-level import, not renderer._inline_only_url_fetcher —
+            # the latter is patched to this spy and would recurse.
+            return _inline_only_url_fetcher(url)
+
+        html_content = f'<html><body><img src="{REMOTE_IMAGE_URL}"></body></html>'
+        with patch("receipt_index.renderer._inline_only_url_fetcher", spy):
+            result = _html_to_pdf_weasyprint(html_content)
+
+        assert result[:5] == b"%PDF-"
+        assert REMOTE_IMAGE_URL in requested
+
+    def test_text_body_render_produces_pdf(self) -> None:
+        raw = RawReceipt(
+            source_id="test",
+            source_name="test-source",
+            source_type="imap",
+            subject="Text Receipt",
+            sender="shop@example.com",
+            date=datetime(2025, 1, 1, tzinfo=UTC),
+            text_body="Your total: $42.99",
+        )
+        result = _render_text_to_pdf(raw)
+
+        assert result[:5] == b"%PDF-"
+        assert len(result) > 500
+
+
+@pytest.mark.skipif(
+    not CHROMIUM_AVAILABLE,
+    reason="Playwright Chromium not installed",
+)
+class TestPlaywrightEgressBlocking:
+    """Rendering with real Chromium must not fetch remote resources."""
+
+    def test_inline_only_html_renders(self) -> None:
+        html_content = (
+            f'<html><body><p>Total: $42.99</p><img src="{INLINE_GIF_DATA_URI}">'
+            "</body></html>"
+        )
+        result = _html_to_pdf_playwright(html_content)
+
+        assert result[:5] == b"%PDF-"
+        assert len(result) > 500
+
+    def test_remote_image_blocked_render_completes(self) -> None:
+        seen: list[str] = []
+
+        def spy(route: Route) -> None:
+            seen.append(route.request.url)
+            # Call the module-level import, not renderer._block_remote_requests —
+            # the latter is patched to this spy and would recurse.
+            _block_remote_requests(route)
+
+        html_content = (
+            f'<html><body><p>Total: $42.99</p><img src="{REMOTE_IMAGE_URL}">'
+            "</body></html>"
+        )
+        started = time.monotonic()
+        with patch("receipt_index.renderer._block_remote_requests", spy):
+            result = _html_to_pdf_playwright(html_content)
+        elapsed = time.monotonic() - started
+
+        assert result[:5] == b"%PDF-"
+        assert REMOTE_IMAGE_URL in seen, "request never reached the route handler"
+        # Blocked != timeout: aborts are immediate, so the render stays fast.
+        assert elapsed < 30


### PR DESCRIPTION
Turns receipt-index from a laptop-bound manual CLI into an unattended Docker compose service for a home Ubuntu server: receipts are ingested every 15 minutes, mirrored to Dropbox, and backed up nightly — with the laptop reduced to an SSH search wrapper.

Plan: `docs/plans/2026-08-01-001-feat-always-on-docker-service-plan.md` (origin brainstorm included). All units U1–U7 and requirements R1–R9 are implemented.

## What's here

- **Render-capable production image** (`Dockerfile`) — the old image couldn't render HTML/text receipts at all (no Playwright browsers, no weasyprint libs), which would have silently DLQ'd every email receipt. Now: pinned `python:3.11-slim-bookworm`, Playwright headless-shell Chromium at `/ms-playwright`, weasyprint runtime libs, checksum-verified supercronic + rclone, `postgresql-client-18` (PGDG) for backups. Two-phase `uv sync` fixes the builder (hatchling needs README.md).
- **Render-time network egress blocking** (`src/receipt_index/renderer.py`) — email HTML is third-party content processed unattended with Chromium's sandbox disabled; the render context now runs with JavaScript off and aborts all non-inline requests (weasyprint gets an inline-only URL fetcher). Side effect: deterministic PDFs, no tracker fetches.
- **Readable container logs** (`src/receipt_index/cli.py`) — pdfminer/fontTools/PIL clamped to WARNING; `basicConfig(force=True)` for deterministic per-command config.
- **Production compose project** (`deploy/`) — postgres:18 (loopback-only port, prod role-init script incl. the `receipt_index_dev_all` role migrations grant to), supercronic scheduler (no-overlap by default, `init`, `shm_size 1g`, `stop_grace_period 5m`, log rotation, pinned `PLAYWRIGHT_BROWSERS_PATH`), crontab with 15-min ingest + offset additive rclone mirrors + nightly rotating `pg_dump` (7-file day-of-week rotation, temp+rename+trap so a partial dump never reaches Dropbox).
- **Runbook** (`docs/user/server-deployment.md`) — provisioning (incl. the compose `$`-in-env corruption gotcha), Go/No-Go gates A–G with schedule-enabled-last, weekly monitoring against a per-status baseline (skipped rows are the silent loss surface), DLQ recovery, Dropbox disaster recovery, and the one-time dev→server cutover appendix with verification queries and abort criteria.
- **Config as template** — `deploy/example.receipt-index.yaml` is the tracked placeholder; the real server config is a git-ignored copy, so no mailbox identity or Drive folder id lives in the repo. Laptop-side commands use a generic `receipt-server` SSH alias.
- **Laptop wrapper** (`scripts/receipt-search`) — `ssh` + `docker compose -p receipt-index exec -T` with `%q` re-quoting so vendor filters like "Acme Parking (U.S.), LLC" survive the remote parse.

## Testing

- 285 unit tests pass (new: egress classifier/route/fetcher suite, logging clamp suite with autouse global-state isolation).
- 41 integration tests pass, including 7 new in-container render smoke tests run against the locally built image (Playwright + weasyprint paths as uid 1000, baked browsers path, binary presence incl. pg_dump 18.x). Also fixed a pre-existing bug where the vision-fallback test never passed a vision agent.
- `deploy/db-init` script was validated against a throwaway postgres:18 container: all roles correct, all 8 migrations apply on a fresh DB (the `_dev_all` role was a verified fresh-deploy blocker), app-role inserts work over TCP.
- Multi-agent code review (10 reviewers) ran with autofix; all P2+ apply-now findings addressed in `ab28d93`.

## Known Residuals (accepted, tracked here)

- **P1 · `.github/workflows/ci.yml`** — CI never builds the production image (the 7 in-container render tests skip) and never installs Playwright browsers (unit egress tests skip). Follow-up: a CI job that builds the image and runs `tests/integration/test_docker_render.py`, plus a `playwright install` step. (testing reviewer, confidence 100)
- **P2 · `deploy/docker-compose.yml`** — the db container receives all app secrets via the shared `env_file` (Anthropic key, IMAP password, GDrive token). Single-tenant box; splitting a `.env.db` is a deliberate open design call. (security reviewer, confidence 100)
- Advisory: DB password appears on `pg_dump` argv (`.pgpass` alternative); `receipt-search` `%q` under non-UTF-8 locales; weasyprint<68 fetcher fallback is dead code under the 68.1 lock; runbook §6.6 queries shown as interactive psql (agent-friendlier as `-c` form); no pg_dump timeout.

## Post-Deploy Monitoring & Validation

- **Gates:** runbook §5 Go/No-Go A–G must pass on the server-built image before the schedule is enabled (render smoke as uid 1000 is the data-loss gate; failed items are permanently skipped by DLQ idempotency).
- **Logs:** `docker compose -p receipt-index logs scheduler` — watch for nonzero ingest exits and supercronic falling-behind warnings (the issue-#36 early signal). One DB-not-ready failure right after a reboot is expected and self-heals.
- **Healthy signals:** per-status `ingest_log` breakdown (success/skipped/failed) unchanged vs the baseline recorded at cutover except success growth; Dropbox `receipts/` newest-file timestamp advances when receipts were expected; 7 rotating dumps in `backups/`.
- **Failure signals / triggers:** growth in `failed` or `skipped` counts → DLQ review (runbook §8.2); falling-behind warnings → revisit 15-min cadence (issue #36); rclone auth errors → re-auth per `deploy/rclone-setup.md` (ingest is unaffected, mirror catches up additively).
- **Window & owner:** repo owner, daily glance for the first week post-cutover, then the weekly routine in runbook §7. Dev pg:5435 is retained until the 7-day retirement criterion in §6.8 passes.

🤖 Compound Engineered with [Claude Code](https://claude.com/claude-code) — planned, reviewed (5 document personas + 10 code personas), and implemented with Fable 5.
