### PR TITLE
chore: scrub personal references from docs and test fixtures

### DIFF
--- a/docs/engineering/adr/0006-config-based-source-definitions.md
+++ b/docs/engineering/adr/0006-config-based-source-definitions.md
@@ -35,7 +35,7 @@ Each source is a named entry with a `type` discriminator:
 sources:
   - name: personal-email
     type: imap
-    host: mail.morison.io
+    host: mail.example.com
     password: ${IMAP_PASSWORD}
     # ...
 
@@ -61,7 +61,7 @@ Phase 2 is a clean break. The Phase 1 env var config helpers are removed. If no 
 - **Self-documenting**: The config file describes the full source topology in one place.
 - **Version-controllable**: Config files (minus secrets) can be committed alongside the project.
 - **Typed validation**: Pydantic discriminated union validates config at load time, catching errors early.
-- **CLI ergonomics**: `--source personal-email` is clearer than `--imap-host mail.morison.io`.
+- **CLI ergonomics**: `--source personal-email` is clearer than `--imap-host mail.example.com`.
 
 ### Negative
 

--- a/docs/engineering/designs/phase-2-gdrive-and-config.md
+++ b/docs/engineering/designs/phase-2-gdrive-and-config.md
@@ -68,9 +68,9 @@ Search order (first found wins):
 sources:
   - name: personal-email
     type: imap
-    host: mail.morison.io
+    host: mail.example.com
     port: 993
-    username: rod@morison.io
+    username: user@example.com
     password: ${IMAP_PASSWORD}           # env var interpolation
     folder: INBOX.Receipts
     use_ssl: true                        # default: true

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -479,7 +479,7 @@ class TestEmailImageAttachments:
     def _mock_agent(self) -> MagicMock:
         mock_result = _mock_agent_result(
             ReceiptMetadata(
-                vendor="Dan Ming",
+                vendor="Acme Property Management",
                 amount=Decimal("3500.00"),
                 date=date(2026, 6, 6),
                 confidence=0.95,
@@ -496,7 +496,7 @@ class TestEmailImageAttachments:
             source_type="imap",
             date=datetime(2026, 6, 6, tzinfo=UTC),
             subject="Screenshot 2026-06-06 at 12.02.34 PM",
-            sender="rod@morison.io",
+            sender="user@example.com",
             attachments=attachments,
         )
 
@@ -507,7 +507,7 @@ class TestEmailImageAttachments:
         agent = self._mock_agent()
         result = extract_metadata(raw, agent=agent)
 
-        assert result.metadata.vendor == "Dan Ming"
+        assert result.metadata.vendor == "Acme Property Management"
         # Image present → message is a list with the text prompt plus binary image
         message = agent.run_sync.call_args[0][0]
         assert isinstance(message, list)


### PR DESCRIPTION
Follow-up to #42. Replaces the remaining personal identifiers on main — IMAP host/username in ADR-0006 and the Phase 2 design doc's YAML samples, and a real vendor name + sender address in `tests/unit/test_extraction.py` fixtures — with `example.com`-style placeholders. Intentionally untouched: the LICENSE copyright, `github.com/rmorison/...` URLs, and the `allowed_users: rmorison` GitHub handle in the Claude workflow (functional, and public by nature).

No behavior change; full unit suite passes (285).

🤖 Compound Engineered with [Claude Code](https://claude.com/claude-code) — Fable 5.